### PR TITLE
Single root load

### DIFF
--- a/data_source.py
+++ b/data_source.py
@@ -128,7 +128,7 @@ class SqlAlchemyDataSource(object):
                 return ''
 
             @staticmethod
-            def load(roots=None, max_depth=0, include_done=False,
+            def load(root_task_id=None, max_depth=0, include_done=False,
                      include_deleted=False, exclude_undeadlined=False):
 
                 query = app.Task.query
@@ -142,10 +142,10 @@ class SqlAlchemyDataSource(object):
                 if exclude_undeadlined:
                     query = query.filter(Task.deadline.isnot(None))
 
-                if roots is None:
+                if root_task_id is None:
                     query = query.filter(Task.parent_id.is_(None))
                 else:
-                    query = query.filter_by(id=roots)
+                    query = query.filter_by(id=root_task_id)
 
                 query = query.order_by(Task.id.asc())
                 query = query.order_by(Task.order_num.desc())

--- a/data_source.py
+++ b/data_source.py
@@ -145,9 +145,7 @@ class SqlAlchemyDataSource(object):
                 if roots is None:
                     query = query.filter(Task.parent_id.is_(None))
                 else:
-                    if not hasattr(roots, '__iter__'):
-                        roots = [roots]
-                    query = query.filter(Task.id.in_(roots))
+                    query = query.filter_by(id=roots)
 
                 query = query.order_by(Task.id.asc())
                 query = query.order_by(Task.order_num.desc())

--- a/logic_layer.py
+++ b/logic_layer.py
@@ -66,7 +66,7 @@ class LogicLayer(object):
                 include_done=show_done, include_deleted=show_deleted,
                 tags=tags)
         else:
-            tasks_h = self.ds.Task.load(roots=None, max_depth=None,
+            tasks_h = self.ds.Task.load(root_task_id=None, max_depth=None,
                                         include_done=show_done,
                                         include_deleted=show_deleted)
             tasks_h = self.sort_by_hierarchy(tasks_h)
@@ -138,7 +138,7 @@ class LogicLayer(object):
         if task is None:
             raise werkzeug.exceptions.NotFound()
 
-        descendants = self.ds.Task.load(roots=task.id, max_depth=None,
+        descendants = self.ds.Task.load(root_task_id=task.id, max_depth=None,
                                         include_done=True,
                                         include_deleted=True)
 
@@ -421,7 +421,7 @@ class LogicLayer(object):
         return option
 
     def do_reset_order_nums(self):
-        tasks_h = self.ds.Task.load(roots=None, max_depth=None,
+        tasks_h = self.ds.Task.load(root_task_id=None, max_depth=None,
                                     include_done=True, include_deleted=True)
         tasks_h = self.sort_by_hierarchy(tasks_h)
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -72,7 +72,7 @@ class DbLoaderTest(unittest.TestCase):
         self.assertEqual(expected_summaries, summaries)
 
     def test_loader_with_single_root(self):
-        tasks = self.app.Task.load(roots=[self.task_ids['parent']])
+        tasks = self.app.Task.load(roots=self.task_ids['parent'])
         self.assertEqual(1, len(tasks))
         self.assertIsInstance(tasks[0], self.app.Task)
         self.assertEqual(self.task_ids['parent'], tasks[0].id)
@@ -345,7 +345,7 @@ class DbLoaderDoneDeletedTest(unittest.TestCase):
         self.assertEqual(expected_summaries, summaries)
 
     def test_done_children_stop_search(self):
-        tasks = self.app.Task.load(roots=[self.task_ids['parent3']],
+        tasks = self.app.Task.load(roots=self.task_ids['parent3'],
                                    max_depth=None)
         self.assertEqual(3, len(tasks))
         self.assertIsInstance(tasks[0], self.app.Task)
@@ -357,7 +357,7 @@ class DbLoaderDoneDeletedTest(unittest.TestCase):
         self.assertEqual(expected_summaries, summaries)
 
     def test_done_children_dont_stop_search_if_included(self):
-        tasks = self.app.Task.load(roots=[self.task_ids['parent3']],
+        tasks = self.app.Task.load(roots=self.task_ids['parent3'],
                                    max_depth=None,
                                    include_done=True)
         self.assertEqual(5, len(tasks))
@@ -423,55 +423,99 @@ class DbLoaderDoneDeletedTest(unittest.TestCase):
         self.assertEqual(expected_summaries, summaries)
 
     def test_deleted_children_stop_search(self):
-        tasks = self.app.Task.load(roots=[self.task_ids['parent3'],
-                                          self.task_ids['parent4'],
-                                          self.task_ids['parent5']],
+        # when
+        tasks = self.app.Task.load(roots=self.task_ids['parent3'],
                                    max_depth=None)
-        self.assertEqual(9, len(tasks))
+        # then
+        self.assertEqual(3, len(tasks))
         self.assertIsInstance(tasks[0], self.app.Task)
         self.assertIsInstance(tasks[1], self.app.Task)
         self.assertIsInstance(tasks[2], self.app.Task)
-        self.assertIsInstance(tasks[3], self.app.Task)
-        self.assertIsInstance(tasks[4], self.app.Task)
-        self.assertIsInstance(tasks[5], self.app.Task)
-        self.assertIsInstance(tasks[6], self.app.Task)
-        self.assertIsInstance(tasks[7], self.app.Task)
-        self.assertIsInstance(tasks[8], self.app.Task)
 
-        expected_summaries = {'parent3', 'child3', 'grandchild3',
-                              'parent4', 'child4', 'grandchild4',
-                              'parent5', 'child5', 'grandchild5'}
+        expected_summaries = {'parent3', 'child3', 'grandchild3'}
+        summaries = set(t.summary for t in tasks)
+        self.assertEqual(expected_summaries, summaries)
+
+        # when
+        tasks = self.app.Task.load(roots=self.task_ids['parent4'],
+                                   max_depth=None)
+        # then
+        self.assertEqual(3, len(tasks))
+        self.assertIsInstance(tasks[0], self.app.Task)
+        self.assertIsInstance(tasks[1], self.app.Task)
+        self.assertIsInstance(tasks[2], self.app.Task)
+
+        expected_summaries = {'parent4', 'child4', 'grandchild4'}
+        summaries = set(t.summary for t in tasks)
+        self.assertEqual(expected_summaries, summaries)
+
+        # when
+        tasks = self.app.Task.load(roots=self.task_ids['parent5'],
+                                   max_depth=None)
+        # then
+        self.assertEqual(3, len(tasks))
+        self.assertIsInstance(tasks[0], self.app.Task)
+        self.assertIsInstance(tasks[1], self.app.Task)
+        self.assertIsInstance(tasks[2], self.app.Task)
+
+        expected_summaries = {'parent5', 'child5', 'grandchild5'}
         summaries = set(t.summary for t in tasks)
         self.assertEqual(expected_summaries, summaries)
 
     def test_deleted_children_do_not_stop_search_if_included(self):
-        tasks = self.app.Task.load(roots=[self.task_ids['parent3'],
-                                          self.task_ids['parent4'],
-                                          self.task_ids['parent5']],
+        # when
+        tasks = self.app.Task.load(roots=self.task_ids['parent3'],
                                    max_depth=None,
                                    include_deleted=True)
-        # self.assertEqual(5, len(tasks))
+        # then
+        self.assertEqual(3, len(tasks))
+        self.assertIsInstance(tasks[0], self.app.Task)
+        self.assertIsInstance(tasks[1], self.app.Task)
+        self.assertIsInstance(tasks[2], self.app.Task)
+
+        expected_summaries = {'parent3', 'child3', 'grandchild3'}
+        summaries = set((t.summary for t in tasks))
+        self.assertEqual(expected_summaries, summaries)
+
+        # when
+        tasks = self.app.Task.load(roots=self.task_ids['parent4'],
+                                   max_depth=None,
+                                   include_deleted=True)
+        # then
+        self.assertEqual(5, len(tasks))
         self.assertIsInstance(tasks[0], self.app.Task)
         self.assertIsInstance(tasks[1], self.app.Task)
         self.assertIsInstance(tasks[2], self.app.Task)
         self.assertIsInstance(tasks[3], self.app.Task)
         self.assertIsInstance(tasks[4], self.app.Task)
 
-        expected_summaries = {'parent3', 'child3', 'grandchild3',
-                              'parent4', 'child4', 'grandchild4',
-                              'great_grandchild4', 'great_great_grandchild4',
-                              'parent5', 'child5', 'grandchild5'}
+        expected_summaries = {'parent4', 'child4', 'grandchild4',
+                              'great_grandchild4', 'great_great_grandchild4'}
+        summaries = set((t.summary for t in tasks))
+        self.assertEqual(expected_summaries, summaries)
+
+        # when
+        tasks = self.app.Task.load(roots=self.task_ids['parent5'],
+                                   max_depth=None,
+                                   include_deleted=True)
+        # then
+        self.assertEqual(3, len(tasks))
+        self.assertIsInstance(tasks[0], self.app.Task)
+        self.assertIsInstance(tasks[1], self.app.Task)
+        self.assertIsInstance(tasks[2], self.app.Task)
+
+        expected_summaries = {'parent5', 'child5', 'grandchild5'}
         summaries = set((t.summary for t in tasks))
         self.assertEqual(expected_summaries, summaries)
 
     def test_done_and_deleted_children_do_not_stop_search_if_included(self):
-        tasks = self.app.Task.load(roots=[self.task_ids['parent3'],
-                                          self.task_ids['parent4'],
-                                          self.task_ids['parent5']],
+        # when
+        tasks = self.app.Task.load(roots=self.task_ids['parent3'],
                                    max_depth=None,
                                    include_done=True,
                                    include_deleted=True)
-        # self.assertEqual(5, len(tasks))
+        # then
+        self.assertEqual(5, len(tasks))
         self.assertIsInstance(tasks[0], self.app.Task)
         self.assertIsInstance(tasks[1], self.app.Task)
         self.assertIsInstance(tasks[2], self.app.Task)
@@ -479,10 +523,42 @@ class DbLoaderDoneDeletedTest(unittest.TestCase):
         self.assertIsInstance(tasks[4], self.app.Task)
 
         expected_summaries = {'parent3', 'child3', 'grandchild3',
-                              'great_grandchild3', 'great_great_grandchild3',
-                              'parent4', 'child4', 'grandchild4',
-                              'great_grandchild4', 'great_great_grandchild4',
-                              'parent5', 'child5', 'grandchild5',
+                              'great_grandchild3', 'great_great_grandchild3'}
+        summaries = set((t.summary for t in tasks))
+        self.assertEqual(expected_summaries, summaries)
+
+        # when
+        tasks = self.app.Task.load(roots=self.task_ids['parent4'],
+                                   max_depth=None,
+                                   include_done=True,
+                                   include_deleted=True)
+        # then
+        self.assertEqual(5, len(tasks))
+        self.assertIsInstance(tasks[0], self.app.Task)
+        self.assertIsInstance(tasks[1], self.app.Task)
+        self.assertIsInstance(tasks[2], self.app.Task)
+        self.assertIsInstance(tasks[3], self.app.Task)
+        self.assertIsInstance(tasks[4], self.app.Task)
+
+        expected_summaries = {'parent4', 'child4', 'grandchild4',
+                              'great_grandchild4', 'great_great_grandchild4'}
+        summaries = set((t.summary for t in tasks))
+        self.assertEqual(expected_summaries, summaries)
+
+        # when
+        tasks = self.app.Task.load(roots=self.task_ids['parent5'],
+                                   max_depth=None,
+                                   include_done=True,
+                                   include_deleted=True)
+        # then
+        self.assertEqual(5, len(tasks))
+        self.assertIsInstance(tasks[0], self.app.Task)
+        self.assertIsInstance(tasks[1], self.app.Task)
+        self.assertIsInstance(tasks[2], self.app.Task)
+        self.assertIsInstance(tasks[3], self.app.Task)
+        self.assertIsInstance(tasks[4], self.app.Task)
+
+        expected_summaries = {'parent5', 'child5', 'grandchild5',
                               'great_grandchild5', 'great_great_grandchild5'}
         summaries = set((t.summary for t in tasks))
         self.assertEqual(expected_summaries, summaries)
@@ -587,24 +663,43 @@ class DbLoaderDeadlinedTest(unittest.TestCase):
         self.assertEqual(expected_summaries, summaries)
 
     def test_loader_undeadlined_do_not_stop_search_if_not_excluded(self):
-        tasks = self.app.Task.load(roots=[self.task_ids['parent1'],
-                                          self.task_ids['parent2']],
+        # when
+        tasks = self.app.Task.load(roots=self.task_ids['parent1'],
                                    max_depth=None)
-        self.assertEqual(10, len(tasks))
+        # then
+        self.assertEqual(5, len(tasks))
         self.assertTrue(all(isinstance(t, self.app.Task) for t in tasks))
 
         expected_summaries = {'parent1', 'child1', 'grandchild1',
-                              'great_grandchild1', 'great_great_grandchild1',
-                              'parent2', 'child2', 'grandchild2',
+                              'great_grandchild1', 'great_great_grandchild1'}
+        summaries = set(t.summary for t in tasks)
+        self.assertEqual(expected_summaries, summaries)
+
+        # when
+        tasks = self.app.Task.load(roots=self.task_ids['parent2'],
+                                   max_depth=None)
+        # then
+        self.assertEqual(5, len(tasks))
+        self.assertTrue(all(isinstance(t, self.app.Task) for t in tasks))
+
+        expected_summaries = {'parent2', 'child2', 'grandchild2',
                               'great_grandchild2', 'great_great_grandchild2'}
         summaries = set(t.summary for t in tasks)
         self.assertEqual(expected_summaries, summaries)
 
     def test_loader_undeadlined_stop_search_if_excluded(self):
-        tasks = self.app.Task.load(roots=[self.task_ids['parent1'],
-                                          self.task_ids['parent2']],
+        # when
+        tasks = self.app.Task.load(roots=self.task_ids['parent1'],
                                    max_depth=None,
                                    exclude_undeadlined=True)
+        # then
+        self.assertEqual(0, len(tasks))
+
+        # when
+        tasks = self.app.Task.load(roots=self.task_ids['parent2'],
+                                   max_depth=None,
+                                   exclude_undeadlined=True)
+        # then
         self.assertEqual(3, len(tasks))
         self.assertTrue(all(isinstance(t, self.app.Task) for t in tasks))
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -77,16 +77,6 @@ class DbLoaderTest(unittest.TestCase):
         self.assertIsInstance(tasks[0], self.app.Task)
         self.assertEqual(self.task_ids['parent'], tasks[0].id)
 
-    def test_loader_with_multiple_roots(self):
-        roots = [self.task_ids['parent'], self.task_ids['parent2']]
-        tasks = self.app.Task.load(roots=roots)
-        self.assertEqual(2, len(tasks))
-        self.assertIsInstance(tasks[0], self.app.Task)
-        self.assertIsInstance(tasks[1], self.app.Task)
-
-        ids = set(t.id for t in tasks)
-        self.assertEqual(set(roots), ids)
-
     def test_loader_with_max_depth_1(self):
 
         # when

--- a/run_tests.py
+++ b/run_tests.py
@@ -72,7 +72,7 @@ class DbLoaderTest(unittest.TestCase):
         self.assertEqual(expected_summaries, summaries)
 
     def test_loader_with_single_root(self):
-        tasks = self.app.Task.load(roots=self.task_ids['parent'])
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent'])
         self.assertEqual(1, len(tasks))
         self.assertIsInstance(tasks[0], self.app.Task)
         self.assertEqual(self.task_ids['parent'], tasks[0].id)
@@ -80,7 +80,8 @@ class DbLoaderTest(unittest.TestCase):
     def test_loader_with_max_depth_1(self):
 
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent2'], max_depth=1)
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent2'],
+                                   max_depth=1)
 
         # then
         self.assertEqual(3, len(tasks))
@@ -95,7 +96,8 @@ class DbLoaderTest(unittest.TestCase):
     def test_loader_with_max_depth_2(self):
 
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent2'], max_depth=2)
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent2'],
+                                   max_depth=2)
 
         # then
         self.assertEqual(4, len(tasks))
@@ -111,7 +113,8 @@ class DbLoaderTest(unittest.TestCase):
     def test_loader_with_max_depth_3(self):
 
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent2'], max_depth=3)
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent2'],
+                                   max_depth=3)
 
         # then
         self.assertEqual(5, len(tasks))
@@ -129,7 +132,8 @@ class DbLoaderTest(unittest.TestCase):
     def test_loader_with_max_depth_4(self):
 
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent2'], max_depth=4)
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent2'],
+                                   max_depth=4)
 
         # then
         self.assertEqual(6, len(tasks))
@@ -148,7 +152,7 @@ class DbLoaderTest(unittest.TestCase):
     def test_loader_with_max_depth_None(self):
 
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent2'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent2'],
                                    max_depth=None)
 
         # then
@@ -168,7 +172,7 @@ class DbLoaderTest(unittest.TestCase):
     def test_loader_with_max_depth_None_2(self):
 
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent'],
                                    max_depth=None)
 
         # then
@@ -345,7 +349,7 @@ class DbLoaderDoneDeletedTest(unittest.TestCase):
         self.assertEqual(expected_summaries, summaries)
 
     def test_done_children_stop_search(self):
-        tasks = self.app.Task.load(roots=self.task_ids['parent3'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent3'],
                                    max_depth=None)
         self.assertEqual(3, len(tasks))
         self.assertIsInstance(tasks[0], self.app.Task)
@@ -357,7 +361,7 @@ class DbLoaderDoneDeletedTest(unittest.TestCase):
         self.assertEqual(expected_summaries, summaries)
 
     def test_done_children_dont_stop_search_if_included(self):
-        tasks = self.app.Task.load(roots=self.task_ids['parent3'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent3'],
                                    max_depth=None,
                                    include_done=True)
         self.assertEqual(5, len(tasks))
@@ -424,7 +428,7 @@ class DbLoaderDoneDeletedTest(unittest.TestCase):
 
     def test_deleted_children_stop_search(self):
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent3'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent3'],
                                    max_depth=None)
         # then
         self.assertEqual(3, len(tasks))
@@ -437,7 +441,7 @@ class DbLoaderDoneDeletedTest(unittest.TestCase):
         self.assertEqual(expected_summaries, summaries)
 
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent4'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent4'],
                                    max_depth=None)
         # then
         self.assertEqual(3, len(tasks))
@@ -450,7 +454,7 @@ class DbLoaderDoneDeletedTest(unittest.TestCase):
         self.assertEqual(expected_summaries, summaries)
 
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent5'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent5'],
                                    max_depth=None)
         # then
         self.assertEqual(3, len(tasks))
@@ -464,7 +468,7 @@ class DbLoaderDoneDeletedTest(unittest.TestCase):
 
     def test_deleted_children_do_not_stop_search_if_included(self):
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent3'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent3'],
                                    max_depth=None,
                                    include_deleted=True)
         # then
@@ -478,7 +482,7 @@ class DbLoaderDoneDeletedTest(unittest.TestCase):
         self.assertEqual(expected_summaries, summaries)
 
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent4'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent4'],
                                    max_depth=None,
                                    include_deleted=True)
         # then
@@ -495,7 +499,7 @@ class DbLoaderDoneDeletedTest(unittest.TestCase):
         self.assertEqual(expected_summaries, summaries)
 
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent5'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent5'],
                                    max_depth=None,
                                    include_deleted=True)
         # then
@@ -510,7 +514,7 @@ class DbLoaderDoneDeletedTest(unittest.TestCase):
 
     def test_done_and_deleted_children_do_not_stop_search_if_included(self):
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent3'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent3'],
                                    max_depth=None,
                                    include_done=True,
                                    include_deleted=True)
@@ -528,7 +532,7 @@ class DbLoaderDoneDeletedTest(unittest.TestCase):
         self.assertEqual(expected_summaries, summaries)
 
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent4'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent4'],
                                    max_depth=None,
                                    include_done=True,
                                    include_deleted=True)
@@ -546,7 +550,7 @@ class DbLoaderDoneDeletedTest(unittest.TestCase):
         self.assertEqual(expected_summaries, summaries)
 
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent5'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent5'],
                                    max_depth=None,
                                    include_done=True,
                                    include_deleted=True)
@@ -664,7 +668,7 @@ class DbLoaderDeadlinedTest(unittest.TestCase):
 
     def test_loader_undeadlined_do_not_stop_search_if_not_excluded(self):
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent1'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent1'],
                                    max_depth=None)
         # then
         self.assertEqual(5, len(tasks))
@@ -676,7 +680,7 @@ class DbLoaderDeadlinedTest(unittest.TestCase):
         self.assertEqual(expected_summaries, summaries)
 
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent2'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent2'],
                                    max_depth=None)
         # then
         self.assertEqual(5, len(tasks))
@@ -689,14 +693,14 @@ class DbLoaderDeadlinedTest(unittest.TestCase):
 
     def test_loader_undeadlined_stop_search_if_excluded(self):
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent1'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent1'],
                                    max_depth=None,
                                    exclude_undeadlined=True)
         # then
         self.assertEqual(0, len(tasks))
 
         # when
-        tasks = self.app.Task.load(roots=self.task_ids['parent2'],
+        tasks = self.app.Task.load(root_task_id=self.task_ids['parent2'],
                                    max_depth=None,
                                    exclude_undeadlined=True)
         # then


### PR DESCRIPTION
This PR changes the `Task.load` method so that it only loads from a single root task, instead of allowing multiple roots.