### PR TITLE
Remove filter by tag from index

### DIFF
--- a/logic_layer.py
+++ b/logic_layer.py
@@ -49,16 +49,10 @@ class LogicLayer(object):
         return list(get_sorted_order(root))
 
     def get_index_data(self, show_deleted, show_done, tags):
-        if tags is not None and len(tags) > 0:
-            tags = tags.split(',')
-            tasks_h = self.ds.Task.load_no_hierarchy(
-                include_done=show_done, include_deleted=show_deleted,
-                tags=tags)
-        else:
-            tasks_h = self.ds.Task.load(root_task_id=None, max_depth=None,
-                                        include_done=show_done,
-                                        include_deleted=show_deleted)
-            tasks_h = self.sort_by_hierarchy(tasks_h)
+        tasks_h = self.ds.Task.load(root_task_id=None, max_depth=None,
+                                    include_done=show_done,
+                                    include_deleted=show_deleted)
+        tasks_h = self.sort_by_hierarchy(tasks_h)
 
         all_tags = self.ds.Tag.query.all()
         return {

--- a/logic_layer.py
+++ b/logic_layer.py
@@ -48,7 +48,7 @@ class LogicLayer(object):
 
         return list(get_sorted_order(root))
 
-    def get_index_data(self, show_deleted, show_done, tags):
+    def get_index_data(self, show_deleted, show_done):
         tasks_h = self.ds.Task.load(root_task_id=None, max_depth=None,
                                     include_done=show_done,
                                     include_deleted=show_deleted)

--- a/tudor.py
+++ b/tudor.py
@@ -185,7 +185,7 @@ def generate_app(db_uri=DEFAULT_TUDOR_DB_URI, ds_factory=None,
 
         tags = request.args.get('tags') or request.cookies.get('tags')
 
-        data = ll.get_index_data(show_deleted, show_done, tags)
+        data = ll.get_index_data(show_deleted, show_done)
 
         resp = make_response(
             render_template('index.t.html',

--- a/tudor.py
+++ b/tudor.py
@@ -183,8 +183,6 @@ def generate_app(db_uri=DEFAULT_TUDOR_DB_URI, ds_factory=None,
         show_deleted = request.cookies.get('show_deleted')
         show_done = request.cookies.get('show_done')
 
-        tags = request.args.get('tags') or request.cookies.get('tags')
-
         data = ll.get_index_data(show_deleted, show_done)
 
         resp = make_response(


### PR DESCRIPTION
This PR alters the index page so that it does not filter the list of tasks shown by tags specified in the query params.