### PR TITLE
Show hide hierarchy

### DIFF
--- a/logic_layer.py
+++ b/logic_layer.py
@@ -57,8 +57,11 @@ class LogicLayer(object):
 
     def get_index_data(self, show_deleted, show_done, show_hierarchy,
                        current_user):
-        tasks_h = self.load(current_user, root_task_id=None, max_depth=None,
-                            include_done=show_done,
+        max_depth = None
+        if not show_hierarchy:
+            max_depth = 0
+        tasks_h = self.load(current_user, root_task_id=None,
+                            max_depth=max_depth, include_done=show_done,
                             include_deleted=show_deleted)
         tasks_h = self.sort_by_hierarchy(tasks_h)
 

--- a/logic_layer.py
+++ b/logic_layer.py
@@ -55,7 +55,8 @@ class LogicLayer(object):
 
         return list(get_sorted_order(root))
 
-    def get_index_data(self, show_deleted, show_done, current_user):
+    def get_index_data(self, show_deleted, show_done, show_hierarchy,
+                       current_user):
         tasks_h = self.load(current_user, root_task_id=None, max_depth=None,
                             include_done=show_done,
                             include_deleted=show_deleted)

--- a/logic_layer.py
+++ b/logic_layer.py
@@ -144,15 +144,18 @@ class LogicLayer(object):
         return task
 
     def get_task_data(self, id, current_user, include_deleted=True,
-                      include_done=True):
+                      include_done=True, show_hierarchy=True):
         task = self.ds.Task.query.filter_by(id=id).first()
         if task is None:
             raise werkzeug.exceptions.NotFound()
         if not self.is_user_authorized_or_admin(task, current_user):
             raise werkzeug.exceptions.Forbidden()
 
+        max_depth = None
+        if not show_hierarchy:
+            max_depth = 1
         descendants = self.load(current_user, root_task_id=task.id,
-                                max_depth=None, include_done=include_done,
+                                max_depth=max_depth, include_done=include_done,
                                 include_deleted=include_deleted)
 
         hierarchy_sort = True

--- a/logic_layer.py
+++ b/logic_layer.py
@@ -69,6 +69,7 @@ class LogicLayer(object):
         return {
             'show_deleted': show_deleted,
             'show_done': show_done,
+            'show_hierarchy': show_hierarchy,
             'tasks_h': tasks_h,
             'all_tags': all_tags,
         }

--- a/templates/index.t.html
+++ b/templates/index.t.html
@@ -26,6 +26,13 @@
         <a href="{{ url_for('show_hide_done', show_done=1) }}">show done</a>
         {% endif -%}
     </p>
+    <p>
+        {%- if show_hierarchy %}
+        <a href="{{ url_for('show_hide_hierarchy', show_hierarchy=0) }}">hide hierarchy</a>
+        {% else %}
+        <a href="{{ url_for('show_hide_hierarchy', show_hierarchy=1) }}">show hierarchy</a>
+        {% endif -%}
+    </p>
     {% if user.is_admin %}
     <p><a href="{{ url_for('purge_deleted_tasks') }}">purge deleted</a></p>
     {% endif %}

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -111,6 +111,13 @@
         <a href="{{ url_for('show_hide_done', show_done=1, next=url_for('view_task', id=task.id)) }}">show done</a>
         {% endif -%}
     </p>
+    <p>
+        {%- if show_hierarchy %}
+        <a href="{{ url_for('show_hide_hierarchy', show_hierarchy=0, next=url_for('view_task', id=task.id)) }}">hide hierarchy</a>
+        {% else %}
+        <a href="{{ url_for('show_hide_hierarchy', show_hierarchy=1, next=url_for('view_task', id=task.id)) }}">show hierarchy</a>
+        {% endif -%}
+    </p>
 </div>
 <div>
     <h4>Notes</h4>

--- a/tests/get_index_data_tests.py
+++ b/tests/get_index_data_tests.py
@@ -95,3 +95,70 @@ class GetIndexDataTest(unittest.TestCase):
 
         # then
         self.assertEqual([None, t2], data['tasks_h'])
+
+    def test_show_hierarchy_true_returns_descendants(self):
+
+        # given
+        t1 = self.Task('t1')
+        t1.order_num = 1
+        t2 = self.Task('t2')
+        t2.order_num = 2
+        t3 = self.Task('t3')
+        t3.parent = t2
+        t3.order_num = 3
+        t4 = self.Task('t4')
+        t4.order_num = 4
+
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(t3)
+        self.db.session.add(t4)
+
+        # when
+        data = self.ll.get_index_data(True, True, True, self.admin)
+
+        # then
+        self.assertEqual([None, t4, t2, t3, t1], data['tasks_h'])
+        tasks = data['tasks_h']
+        self.assertEqual(0, tasks[1].depth)
+        self.assertEqual(0, tasks[2].depth)
+        self.assertEqual(1, tasks[3].depth)
+        self.assertEqual(0, tasks[4].depth)
+        self.assertEqual(0, t1.depth)
+        self.assertEqual(0, t2.depth)
+        self.assertEqual(1, t3.depth)
+        self.assertEqual(0, t4.depth)
+
+    def test_show_hierarchy_false_returns_only_top_level_tasks(self):
+
+        # given
+        t1 = self.Task('t1')
+        t1.order_num = 1
+        t2 = self.Task('t2')
+        t2.order_num = 2
+        t3 = self.Task('t3')
+        t3.parent = t2
+        t3.order_num = 3
+        t4 = self.Task('t4')
+        t4.order_num = 4
+
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(t3)
+        self.db.session.add(t4)
+
+        # when
+        data = self.ll.get_index_data(True, True, False, self.admin)
+
+        # then
+        self.assertEqual([None, t4, t2, t1], data['tasks_h'])
+        tasks = data['tasks_h']
+        self.assertEqual(0, tasks[1].depth)
+        self.assertEqual(0, tasks[2].depth)
+        self.assertEqual(0, tasks[3].depth)
+        self.assertEqual(0, t1.depth)
+        self.assertEqual(0, t2.depth)
+        self.assertEqual(0, t4.depth)
+
+        # depth on the child remains at 0
+        self.assertEqual(0, t3.depth)

--- a/tests/get_index_data_tests.py
+++ b/tests/get_index_data_tests.py
@@ -42,7 +42,7 @@ class GetIndexDataTest(unittest.TestCase):
         self.db.session.add(tag1)
 
         # when
-        data = self.ll.get_index_data(True, True, self.admin)
+        data = self.ll.get_index_data(True, True, True, self.admin)
 
         # then
         self.assertEqual([None, t4, t2, t3, t1], data['tasks_h'])
@@ -50,24 +50,24 @@ class GetIndexDataTest(unittest.TestCase):
 
     def test_show_deleted_returns_as_is(self):
         # when
-        data = self.ll.get_index_data(True, True, self.admin)
+        data = self.ll.get_index_data(True, True, True, self.admin)
 
         # then
         self.assertTrue(data['show_deleted'])
         # when
-        data = self.ll.get_index_data(False, True, self.admin)
+        data = self.ll.get_index_data(False, True, True, self.admin)
 
         # then
         self.assertFalse(data['show_deleted'])
 
     def test_show_done_returns_as_is(self):
         # when
-        data = self.ll.get_index_data(True, True, self.admin)
+        data = self.ll.get_index_data(True, True, True, self.admin)
 
         # then
         self.assertTrue(data['show_done'])
         # when
-        data = self.ll.get_index_data(True, False, self.admin)
+        data = self.ll.get_index_data(True, False, True, self.admin)
 
         # then
         self.assertFalse(data['show_done'])
@@ -91,7 +91,7 @@ class GetIndexDataTest(unittest.TestCase):
         self.db.session.add(tul)
 
         # when
-        data = self.ll.get_index_data(True, True, self.user)
+        data = self.ll.get_index_data(True, True, True, self.user)
 
         # then
         self.assertEqual([None, t2], data['tasks_h'])

--- a/tudor.py
+++ b/tudor.py
@@ -203,7 +203,7 @@ def generate_app(db_uri=DEFAULT_TUDOR_DB_URI, ds_factory=None,
         show_deleted = request.cookies.get('show_deleted')
         show_done = request.cookies.get('show_done')
 
-        data = ll.get_index_data(show_deleted, show_done, current_user)
+        data = ll.get_index_data(show_deleted, show_done, True, current_user)
 
         resp = make_response(
             render_template('index.t.html',

--- a/tudor.py
+++ b/tudor.py
@@ -318,13 +318,16 @@ def generate_app(db_uri=DEFAULT_TUDOR_DB_URI, ds_factory=None,
     def view_task(id):
         show_deleted = request.cookies.get('show_deleted')
         show_done = request.cookies.get('show_done')
+        show_hierarchy = request.cookies.get('show_hierarchy', True)
         data = ll.get_task_data(id, current_user, include_deleted=show_deleted,
-                                include_done=show_done)
+                                include_done=show_done,
+                                show_hierarchy=show_hierarchy)
 
         return render_template('task.t.html', task=data['task'],
                                descendants=data['descendants'],
                                cycle=itertools.cycle,
-                               show_deleted=show_deleted, show_done=show_done)
+                               show_deleted=show_deleted, show_done=show_done,
+                               show_hierarchy=show_hierarchy)
 
     @app.route('/note/new', methods=['POST'])
     @login_required

--- a/tudor.py
+++ b/tudor.py
@@ -202,13 +202,16 @@ def generate_app(db_uri=DEFAULT_TUDOR_DB_URI, ds_factory=None,
     def index():
         show_deleted = request.cookies.get('show_deleted')
         show_done = request.cookies.get('show_done')
+        show_hierarchy = request.cookies.get('show_hierarchy', True)
 
-        data = ll.get_index_data(show_deleted, show_done, True, current_user)
+        data = ll.get_index_data(show_deleted, show_done, show_hierarchy,
+                                 current_user)
 
         resp = make_response(
             render_template('index.t.html',
                             show_deleted=data['show_deleted'],
                             show_done=data['show_done'],
+                            show_hierarchy=data['show_hierarchy'],
                             cycle=itertools.cycle,
                             user=current_user,
                             tasks_h=data['tasks_h'],
@@ -624,6 +627,18 @@ def generate_app(db_uri=DEFAULT_TUDOR_DB_URI, ds_factory=None,
             resp.set_cookie('show_done', '1')
         else:
             resp.set_cookie('show_done', '')
+        return resp
+
+    @app.route('/show_hide_hierarchy')
+    @login_required
+    def show_hide_hierarchy():
+        show_hierarchy = request.args.get('show_hierarchy')
+        resp = make_response(
+            redirect(request.args.get('next') or url_for('index')))
+        if show_hierarchy and show_hierarchy != '0':
+            resp.set_cookie('show_hierarchy', '1')
+        else:
+            resp.set_cookie('show_hierarchy', '')
         return resp
 
     @app.route('/options', methods=['GET', 'POST'])


### PR DESCRIPTION
This PR adds the ability to show or hide tasks' descendant on both the main index page and the view-task page.