### PR TITLE
Pass the current user.

### DIFF
--- a/tudor.py
+++ b/tudor.py
@@ -222,7 +222,7 @@ def generate_app(db_uri=DEFAULT_TUDOR_DB_URI, ds_factory=None,
     @login_required
     def deadlines():
 
-        data = ll.get_deadlines_data()
+        data = ll.get_deadlines_data(current_user)
 
         return make_response(
             render_template(


### PR DESCRIPTION
This PR fixes a bug in `/deadlines` where the call wasn't passing the current user to `get_deadlines_data`.