### PR TITLE
Add the viewport meta element to all pages.

### DIFF
--- a/templates/base.t.html
+++ b/templates/base.t.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     {% block head %}
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet"/>
     <link rel="stylesheet" href="{{ url_for('static', filename='tudor.css') }}" />


### PR DESCRIPTION
This PR adds a `<meta name="viewport ...>` element to all pages to properly scale the page on mobile browsers.