### PR TITLE
Prioritize before/after

### DIFF
--- a/data_source.py
+++ b/data_source.py
@@ -40,8 +40,16 @@ class SqlAlchemyDataSource(object):
             db.Column('dependant_id', db.Integer, db.ForeignKey('task.id'),
                       primary_key=True))
 
+        task_prioritize_table = db.Table(
+            'task_prioritize',
+            db.Column('prioritize_before_id', db.Integer,
+                      db.ForeignKey('task.id'), primary_key=True),
+            db.Column('prioritize_after_id', db.Integer,
+                      db.ForeignKey('task.id'), primary_key=True))
+
         Task = generate_task_class(db, tags_tasks_table, users_tasks_table,
-                                   task_dependencies_table)
+                                   task_dependencies_table,
+                                   task_prioritize_table)
         Note = generate_note_class(db)
         Attachment = generate_attachment_class(db)
         User = generate_user_class(db, app.bcrypt)

--- a/logic_layer.py
+++ b/logic_layer.py
@@ -1158,3 +1158,91 @@ class LogicLayer(object):
                                                             task_id,
                                                             current_user)
         return task, dependant
+
+    def do_add_prioritize_before_to_task(self, task_id, prioritize_before_id,
+                                         current_user):
+        if task_id is None:
+            raise ValueError("No task_id was specified.")
+        if prioritize_before_id is None:
+            raise ValueError("No prioritize_before_id was specified.")
+        if current_user is None:
+            raise ValueError("No current_user was specified.")
+
+        task = self.ds.Task.query.get(task_id)
+        if task is None:
+            raise werkzeug.exceptions.NotFound(
+                "No task found for the id '{}'".format(task_id))
+        if not self.is_user_authorized_or_admin(task, current_user):
+            raise werkzeug.exceptions.Forbidden()
+
+        prioritize_before = self.ds.Task.query.get(prioritize_before_id)
+        if prioritize_before is None:
+            raise werkzeug.exceptions.NotFound(
+                "No task found for the id '{}'".format(prioritize_before_id))
+        if not self.is_user_authorized_or_admin(prioritize_before,
+                                                current_user):
+            raise werkzeug.exceptions.Forbidden()
+
+        if prioritize_before not in task.prioritize_before:
+            task.prioritize_before.append(prioritize_before)
+
+        return task, prioritize_before
+
+    def do_remove_prioritize_before_from_task(self, task_id,
+                                              prioritize_before_id,
+                                              current_user):
+        if task_id is None:
+            raise ValueError("No task_id was specified.")
+        if prioritize_before_id is None:
+            raise ValueError("No prioritize_before_id was specified.")
+        if current_user is None:
+            raise ValueError("No current_user was specified.")
+
+        task = self.ds.Task.query.get(task_id)
+        if task is None:
+            raise werkzeug.exceptions.NotFound(
+                "No task found for the id '{}'".format(task_id))
+        if not self.is_user_authorized_or_admin(task, current_user):
+            raise werkzeug.exceptions.Forbidden()
+
+        prioritize_before = self.ds.Task.query.get(prioritize_before_id)
+        if prioritize_before is None:
+            raise werkzeug.exceptions.NotFound(
+                "No task found for the id '{}'".format(prioritize_before_id))
+        if not self.is_user_authorized_or_admin(prioritize_before,
+                                                current_user):
+            raise werkzeug.exceptions.Forbidden()
+
+        if prioritize_before in task.prioritize_before:
+            task.prioritize_before.remove(prioritize_before)
+            self.db.session.add(task)
+            self.db.session.add(prioritize_before)
+
+        return task, prioritize_before
+
+    def do_add_prioritize_after_to_task(self, task_id, prioritize_after_id,
+                                        current_user):
+        if task_id is None:
+            raise ValueError("No task_id was specified.")
+        if prioritize_after_id is None:
+            raise ValueError("No prioritize_after_id was specified.")
+        if current_user is None:
+            raise ValueError("No current_user was specified.")
+
+        prioritize_after, task = self.do_add_prioritize_before_to_task(
+            prioritize_after_id, task_id, current_user)
+        return task, prioritize_after
+
+    def do_remove_prioritize_after_from_task(self, task_id,
+                                             prioritize_after_id,
+                                             current_user):
+        if task_id is None:
+            raise ValueError("No task_id was specified.")
+        if prioritize_after_id is None:
+            raise ValueError("No prioritize_after_id was specified.")
+        if current_user is None:
+            raise ValueError("No current_user was specified.")
+
+        prioritize_after, task = self.do_remove_prioritize_before_from_task(
+            prioritize_after_id, task_id, current_user)
+        return task, prioritize_after

--- a/models/task.py
+++ b/models/task.py
@@ -150,4 +150,16 @@ def generate_task_class(db, tags_tasks_table, users_tasks_table,
 
             return False
 
+        def contains_priority_cycle(self, visited=None):
+            if visited is None:
+                visited = set()
+            if self in visited:
+                return True
+            visited = set(visited)
+            visited.add(self)
+            for before in self.prioritize_before:
+                if before.contains_priority_cycle(visited):
+                    return True
+            return False
+
     return Task

--- a/models/task.py
+++ b/models/task.py
@@ -35,6 +35,10 @@ def generate_task_class(db, tags_tasks_table, users_tasks_table,
             secondaryjoin=task_dependencies_table.c.dependee_id == id,
             backref='dependants')
 
+        # self is after self.prioritze_before's
+        # self has lower priority that self.prioritze_before's
+        # self is before self.prioritze_after's
+        # self has higher priority that self.prioritze_after's
         prioritize_before = db.relationship(
             'Task', secondary=task_prioritize_table,
             primaryjoin=task_prioritize_table.c.prioritize_after_id == id,

--- a/models/task.py
+++ b/models/task.py
@@ -5,7 +5,7 @@ from conversions import str_from_datetime
 
 
 def generate_task_class(db, tags_tasks_table, users_tasks_table,
-                        task_dependencies_table):
+                        task_dependencies_table, task_prioritize_table):
     class Task(db.Model):
         id = db.Column(db.Integer, primary_key=True)
         summary = db.Column(db.String(100))
@@ -34,6 +34,12 @@ def generate_task_class(db, tags_tasks_table, users_tasks_table,
             primaryjoin=task_dependencies_table.c.dependant_id == id,
             secondaryjoin=task_dependencies_table.c.dependee_id == id,
             backref='dependants')
+
+        prioritize_before = db.relationship(
+            'Task', secondary=task_prioritize_table,
+            primaryjoin=task_prioritize_table.c.prioritize_after_id == id,
+            secondaryjoin=task_prioritize_table.c.prioritize_before_id == id,
+            backref='prioritize_after')
 
         depth = 0
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -34,6 +34,7 @@ from tests.search_tests import *
 from tests.task_dependencies_tests import *
 from tests.ll_task_tags_tests import *
 from tests.get_lowest_highest_order_num import *
+from tests.task_prioritize_tests import *
 
 
 def run():

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -118,6 +118,41 @@
                 <!--<a href="{ { url_for('pick_dependant_to_add', task_id=task.id) } }">Pick a task</a>-->
             </td>
         </tr>
+        <tr>
+            <td>Is prioritized before</td>
+            <td>
+                {% for ptask in task.prioritize_after %}
+                    <a href="{{ url_for('view_task', id=ptask.id) }}" {{ ptask.get_css_class_attr()|safe }}>{{ ptask.summary }} ({{ ptask.id }})</a>
+                    <!--<a href="{ { url_for('remove_prioritize_after_from_task', task_id=task.id, other_id=ptask.id) }}">-->
+                        <!--<img src="{{ url_for('static', filename='delete.png') }}" />-->
+                    <!--</a>-->
+
+                {% endfor %}
+                <!--<form action="{ { url_for('add_prioritize_after_to_task', task_id=task.id) }}" method="post">-->
+                    <!--<input type="text" name="other_id" />-->
+                    <!--<input type="hidden" name="next_url"-->
+                           <!--value="{{ url_for('view_task', id=task.id) }}" />-->
+                <!--</form>-->
+                <!--<a href="{ { url_for('pick_prioritize_after_to_add', task_id=task.id) } }">Pick a task</a>-->
+            </td>
+        </tr>
+        <tr>
+            <td>Is prioritized after</td>
+            <td>
+                {% for ptask in task.prioritize_before %}
+                    <a href="{{ url_for('view_task', id=ptask.id) }}" {{ ptask.get_css_class_attr()|safe }}>{{ ptask.summary }} ({{ ptask.id }})</a>
+                    <!--<a href="{ { url_for('remove_prioritize_before_from_task', task_id=task.id, other_id=ptask.id) }}">-->
+                        <!--<img src="{{ url_for('static', filename='delete.png') }}" />-->
+                    <!--</a>-->
+                {% endfor %}
+                <!--<form action="{ { url_for('add_prioritize_before_to_task', task_id=task.id) }}" method="post">-->
+                    <!--<input type="text" name="other_id" />-->
+                    <!--<input type="hidden" name="next_url"-->
+                           <!--value="{{ url_for('view_task', id=task.id) }}" />-->
+                <!--</form>-->
+                <!--<a href="{ { url_for('pick_prioritize_before_to_add', task_id=task.id) } }">Pick a task</a>-->
+            </td>
+        </tr>
     </table>
     <p></p>
     <a class="btn btn-primary" href="{{ url_for('edit_task', id=task.id) }}">Edit</a>

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -123,16 +123,16 @@
             <td>
                 {% for ptask in task.prioritize_after %}
                     <a href="{{ url_for('view_task', id=ptask.id) }}" {{ ptask.get_css_class_attr()|safe }}>{{ ptask.summary }} ({{ ptask.id }})</a>
-                    <!--<a href="{ { url_for('remove_prioritize_after_from_task', task_id=task.id, other_id=ptask.id) }}">-->
-                        <!--<img src="{{ url_for('static', filename='delete.png') }}" />-->
-                    <!--</a>-->
+                    <a href="{{ url_for('remove_prioritize_after_from_task', task_id=task.id, prioritize_after_id=ptask.id) }}">
+                        <img src="{{ url_for('static', filename='delete.png') }}" />
+                    </a>
 
                 {% endfor %}
-                <!--<form action="{ { url_for('add_prioritize_after_to_task', task_id=task.id) }}" method="post">-->
-                    <!--<input type="text" name="other_id" />-->
-                    <!--<input type="hidden" name="next_url"-->
-                           <!--value="{{ url_for('view_task', id=task.id) }}" />-->
-                <!--</form>-->
+                <form action="{{ url_for('add_prioritize_after_to_task', task_id=task.id) }}" method="post">
+                    <input type="text" name="prioritize_after_id" />
+                    <input type="hidden" name="next_url"
+                           value="{{ url_for('view_task', id=task.id) }}" />
+                </form>
                 <!--<a href="{ { url_for('pick_prioritize_after_to_add', task_id=task.id) } }">Pick a task</a>-->
             </td>
         </tr>
@@ -141,15 +141,15 @@
             <td>
                 {% for ptask in task.prioritize_before %}
                     <a href="{{ url_for('view_task', id=ptask.id) }}" {{ ptask.get_css_class_attr()|safe }}>{{ ptask.summary }} ({{ ptask.id }})</a>
-                    <!--<a href="{ { url_for('remove_prioritize_before_from_task', task_id=task.id, other_id=ptask.id) }}">-->
-                        <!--<img src="{{ url_for('static', filename='delete.png') }}" />-->
-                    <!--</a>-->
+                    <a href="{{ url_for('remove_prioritize_before_from_task', task_id=task.id, prioritize_before_id=ptask.id) }}">
+                        <img src="{{ url_for('static', filename='delete.png') }}" />
+                    </a>
                 {% endfor %}
-                <!--<form action="{ { url_for('add_prioritize_before_to_task', task_id=task.id) }}" method="post">-->
-                    <!--<input type="text" name="other_id" />-->
-                    <!--<input type="hidden" name="next_url"-->
-                           <!--value="{{ url_for('view_task', id=task.id) }}" />-->
-                <!--</form>-->
+                <form action="{{ url_for('add_prioritize_before_to_task', task_id=task.id) }}" method="post">
+                    <input type="text" name="prioritize_before_id" />
+                    <input type="hidden" name="next_url"
+                           value="{{ url_for('view_task', id=task.id) }}" />
+                </form>
                 <!--<a href="{ { url_for('pick_prioritize_before_to_add', task_id=task.id) } }">Pick a task</a>-->
             </td>
         </tr>

--- a/tests/task_prioritize_tests.py
+++ b/tests/task_prioritize_tests.py
@@ -57,3 +57,64 @@ class TaskPrioritizeTest(unittest.TestCase):
         self.assertEqual(0, len(t2.prioritize_after))
         self.assertTrue(t2 in t1.prioritize_after)
         self.assertTrue(t1 in t2.prioritize_before)
+
+    def test_cycle_check_yields_false_for_no_cycles(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        t1.prioritize_before.append(t2)
+
+        # expect
+        self.assertFalse(t1.contains_priority_cycle())
+        self.assertFalse(t2.contains_priority_cycle())
+
+    def test_cycle_check_yields_true_for_cycles(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        t1.prioritize_before.append(t2)
+        t2.prioritize_before.append(t1)
+
+        # expect
+        self.assertTrue(t1.contains_priority_cycle())
+        self.assertTrue(t2.contains_priority_cycle())
+
+    def test_cycle_check_yields_true_for_long_cycles(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        t3 = self.Task('t3')
+        t4 = self.Task('t4')
+        t5 = self.Task('t5')
+        t6 = self.Task('t6')
+        t1.prioritize_before.append(t2)
+        t2.prioritize_before.append(t3)
+        t3.prioritize_before.append(t4)
+        t4.prioritize_before.append(t5)
+        t5.prioritize_before.append(t6)
+        t6.prioritize_before.append(t1)
+
+        # expect
+        self.assertTrue(t1.contains_priority_cycle())
+        self.assertTrue(t2.contains_priority_cycle())
+        self.assertTrue(t3.contains_priority_cycle())
+        self.assertTrue(t4.contains_priority_cycle())
+        self.assertTrue(t5.contains_priority_cycle())
+        self.assertTrue(t6.contains_priority_cycle())
+
+    def test_cycle_check_yields_false_for_trees(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        t3 = self.Task('t3')
+        t4 = self.Task('t4')
+        t1.prioritize_before.append(t2)
+        t1.prioritize_before.append(t3)
+        t2.prioritize_before.append(t4)
+        t3.prioritize_before.append(t4)
+
+        # expect
+        self.assertFalse(t1.contains_priority_cycle())
+        self.assertFalse(t2.contains_priority_cycle())
+        self.assertFalse(t3.contains_priority_cycle())
+        self.assertFalse(t4.contains_priority_cycle())

--- a/tests/task_prioritize_tests.py
+++ b/tests/task_prioritize_tests.py
@@ -118,3 +118,1008 @@ class TaskPrioritizeTest(unittest.TestCase):
         self.assertFalse(t2.contains_priority_cycle())
         self.assertFalse(t3.contains_priority_cycle())
         self.assertFalse(t4.contains_priority_cycle())
+
+
+class TaskPrioritizeBeforeLogicLayerTest(unittest.TestCase):
+    def setUp(self):
+        self.app = generate_app(db_uri='sqlite://')
+        self.db = self.app.ds.db
+        self.db.create_all()
+        self.ll = self.app.ll
+        self.Task = self.app.Task
+        self.User = self.app.User
+
+    def test_add_prioritize_before_adds_prioritize_before(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t2.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+
+        # when
+        results = self.ll.do_add_prioritize_before_to_task(t1.id, t2.id, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(1, len(t1.prioritize_before))
+        self.assertEqual(1, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertTrue(t2 in t1.prioritize_before)
+        self.assertTrue(t1 in t2.prioritize_after)
+        self.assertIsNotNone(results)
+        self.assertEqual([t1, t2], list(results))
+
+    def test_if_already_added_still_succeeds(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        t1.prioritize_before.append(t2)
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t2.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(1, len(t1.prioritize_before))
+        self.assertEqual(1, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertTrue(t2 in t1.prioritize_before)
+        self.assertTrue(t1 in t2.prioritize_after)
+
+        # when
+        results = self.ll.do_add_prioritize_before_to_task(t1.id, t2.id, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(1, len(t1.prioritize_before))
+        self.assertEqual(1, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertTrue(t2 in t1.prioritize_before)
+        self.assertTrue(t1 in t2.prioritize_after)
+        self.assertIsNotNone(results)
+        self.assertEqual([t1, t2], list(results))
+
+    def test_null_ids_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t2.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+
+        # expect
+        self.assertRaises(ValueError, self.ll.do_add_prioritize_before_to_task,
+                          None, t2.id, user)
+
+        # expect
+        self.assertRaises(ValueError, self.ll.do_add_prioritize_before_to_task,
+                          t1.id, None, user)
+
+        # expect
+        self.assertRaises(ValueError, self.ll.do_add_prioritize_before_to_task,
+                          None, None, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+
+    def test_null_user_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t2.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+
+        # expect
+        self.assertRaises(ValueError, self.ll.do_add_prioritize_before_to_task,
+                          t1.id, t2.id, None)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+
+    def test_user_not_authorized_for_task_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t2.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+
+        # expect
+        self.assertRaises(Forbidden, self.ll.do_add_prioritize_before_to_task,
+                          t1.id, t2.id, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+
+    def test_user_not_authorized_for_prioritize_before_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+
+        # expect
+        self.assertRaises(Forbidden, self.ll.do_add_prioritize_before_to_task,
+                          t1.id, t2.id, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+
+    def test_task_not_found_raises_exception(self):
+        # given
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t2.users.append(user)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertIsNone(self.app.ds.Task.query.get(t2.id + 1))
+
+        # expect
+        self.assertRaises(NotFound, self.ll.do_add_prioritize_before_to_task,
+                          t2.id + 1, t2.id, user)
+
+        # then
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertIsNone(self.app.ds.Task.query.get(t2.id+1))
+
+    def test_prioritize_before_not_found_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertIsNone(self.app.ds.Task.query.get(t1.id + 1))
+
+        # expect
+        self.assertRaises(NotFound, self.ll.do_add_prioritize_before_to_task,
+                          t1.id, t1.id + 1, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertIsNone(self.app.ds.Task.query.get(t1.id + 1))
+
+    def test_remove_prioritize_before_removes_prioritize_before(self):
+
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t2.users.append(user)
+        t1.prioritize_before.append(t2)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(1, len(t1.prioritize_before))
+        self.assertEqual(1, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertTrue(t2 in t1.prioritize_before)
+        self.assertTrue(t1 in t2.prioritize_after)
+
+        # when
+        results = self.ll.do_remove_prioritize_before_from_task(t1.id, t2.id,
+                                                                user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertIsNotNone(results)
+        self.assertEqual([t1, t2], list(results))
+
+    def test_if_prioritize_before_already_removed_still_succeeds(self):
+
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t2.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+
+        # when
+        results = self.ll.do_remove_prioritize_before_from_task(t1.id, t2.id,
+                                                                user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertIsNotNone(results)
+        self.assertEqual([t1, t2], list(results))
+
+    def test_remove_prioritize_before_with_null_ids_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t2.users.append(user)
+        t1.prioritize_before.append(t2)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(1, len(t1.prioritize_before))
+        self.assertEqual(1, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertTrue(t2 in t1.prioritize_before)
+        self.assertTrue(t1 in t2.prioritize_after)
+
+        # expect
+        self.assertRaises(ValueError,
+                          self.ll.do_remove_prioritize_before_from_task,
+                          None, t2.id, user)
+
+        # expect
+        self.assertRaises(ValueError,
+                          self.ll.do_remove_prioritize_before_from_task,
+                          t1.id, None, user)
+
+        # expect
+        self.assertRaises(ValueError,
+                          self.ll.do_remove_prioritize_before_from_task,
+                          None, None, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(1, len(t1.prioritize_before))
+        self.assertEqual(1, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertTrue(t2 in t1.prioritize_before)
+        self.assertTrue(t1 in t2.prioritize_after)
+
+    def test_remove_prioritize_before_with_null_user_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t2.users.append(user)
+        t1.prioritize_before.append(t2)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(1, len(t1.prioritize_before))
+        self.assertEqual(1, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertTrue(t2 in t1.prioritize_before)
+        self.assertTrue(t1 in t2.prioritize_after)
+
+        # expect
+        self.assertRaises(ValueError,
+                          self.ll.do_remove_prioritize_before_from_task,
+                          t1.id, t2.id, None)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(1, len(t1.prioritize_before))
+        self.assertEqual(1, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertTrue(t2 in t1.prioritize_before)
+        self.assertTrue(t1 in t2.prioritize_after)
+
+    def test_remove_prioritize_before_user_unauthd_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t2.users.append(user)
+        t1.prioritize_before.append(t2)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+        # note that this situation shouldn't happen anyways. a task shouldn't
+        # be prioritized before another task unless both share a common set of
+        # one or more authorized users
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(1, len(t1.prioritize_before))
+        self.assertEqual(1, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertTrue(t2 in t1.prioritize_before)
+        self.assertTrue(t1 in t2.prioritize_after)
+
+        # expect
+        self.assertRaises(Forbidden,
+                          self.ll.do_remove_prioritize_before_from_task,
+                          t1.id, t2.id, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(1, len(t1.prioritize_before))
+        self.assertEqual(1, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertTrue(t2 in t1.prioritize_before)
+        self.assertTrue(t1 in t2.prioritize_after)
+
+    def test_remove_user_not_authd_for_prioritizebefore_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t1.prioritize_before.append(t2)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+        # note that this situation shouldn't happen anyways. a task shouldn't
+        # be prioritized before another task unless both share a common set of
+        # one or more authorized users
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(1, len(t1.prioritize_before))
+        self.assertEqual(1, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertTrue(t2 in t1.prioritize_before)
+        self.assertTrue(t1 in t2.prioritize_after)
+
+        # expect
+        self.assertRaises(Forbidden,
+                          self.ll.do_remove_prioritize_before_from_task,
+                          t1.id, t2.id, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(1, len(t1.prioritize_before))
+        self.assertEqual(1, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertTrue(t2 in t1.prioritize_before)
+        self.assertTrue(t1 in t2.prioritize_after)
+
+    def test_remove_prioritize_before_task_not_found_raises_exception(self):
+        # given
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t2.users.append(user)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertIsNone(self.app.ds.Task.query.get(t2.id + 1))
+
+        # expect
+        self.assertRaises(NotFound,
+                          self.ll.do_remove_prioritize_before_from_task,
+                          t2.id + 1, t2.id, user)
+
+        # then
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertIsNone(self.app.ds.Task.query.get(t2.id+1))
+
+    def test_remove_prioritize_before_when_not_found_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertIsNone(self.app.ds.Task.query.get(t1.id + 1))
+
+        # expect
+        self.assertRaises(NotFound,
+                          self.ll.do_remove_prioritize_before_from_task,
+                          t1.id, t1.id + 1, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertIsNone(self.app.ds.Task.query.get(t1.id + 1))
+
+
+class TaskPrioritizeAfterLogicLayerTest(unittest.TestCase):
+
+    def setUp(self):
+        self.app = generate_app(db_uri='sqlite://')
+        self.db = self.app.ds.db
+        self.db.create_all()
+        self.ll = self.app.ll
+        self.Task = self.app.Task
+        self.User = self.app.User
+
+    def test_add_prioritize_after_adds_prioritize_after(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t2.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+
+        # when
+        results = self.ll.do_add_prioritize_after_to_task(t1.id, t2.id, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(1, len(t1.prioritize_after))
+        self.assertEqual(1, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertTrue(t2 in t1.prioritize_after)
+        self.assertTrue(t1 in t2.prioritize_before)
+        self.assertIsNotNone(results)
+        self.assertEqual([t1, t2], list(results))
+
+    def test_if_already_added_still_succeeds(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        t1.prioritize_after.append(t2)
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t2.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(1, len(t1.prioritize_after))
+        self.assertEqual(1, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertTrue(t2 in t1.prioritize_after)
+        self.assertTrue(t1 in t2.prioritize_before)
+
+        # when
+        results = self.ll.do_add_prioritize_after_to_task(t1.id, t2.id, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(1, len(t1.prioritize_after))
+        self.assertEqual(1, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertTrue(t2 in t1.prioritize_after)
+        self.assertTrue(t1 in t2.prioritize_before)
+        self.assertIsNotNone(results)
+        self.assertEqual([t1, t2], list(results))
+
+    def test_null_ids_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t2.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+
+        # expect
+        self.assertRaises(ValueError, self.ll.do_add_prioritize_after_to_task,
+                          None, t2.id, user)
+
+        # expect
+        self.assertRaises(ValueError, self.ll.do_add_prioritize_after_to_task,
+                          t1.id, None, user)
+
+        # expect
+        self.assertRaises(ValueError, self.ll.do_add_prioritize_after_to_task,
+                          None, None, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+
+    def test_null_user_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t2.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+
+        # expect
+        self.assertRaises(ValueError, self.ll.do_add_prioritize_after_to_task,
+                          t1.id, t2.id, None)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+
+    def test_user_not_authorized_for_task_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t2.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+
+        # expect
+        self.assertRaises(Forbidden, self.ll.do_add_prioritize_after_to_task,
+                          t1.id, t2.id, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+
+    def test_user_not_authorized_for_prioritize_after_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+
+        # expect
+        self.assertRaises(Forbidden, self.ll.do_add_prioritize_after_to_task,
+                          t1.id, t2.id, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+
+    def test_task_not_found_raises_exception(self):
+        # given
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t2.users.append(user)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertIsNone(self.app.ds.Task.query.get(t2.id + 1))
+
+        # expect
+        self.assertRaises(NotFound, self.ll.do_add_prioritize_after_to_task,
+                          t2.id + 1, t2.id, user)
+
+        # then
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertIsNone(self.app.ds.Task.query.get(t2.id+1))
+
+    def test_prioritize_after_not_found_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertIsNone(self.app.ds.Task.query.get(t1.id + 1))
+
+        # expect
+        self.assertRaises(NotFound, self.ll.do_add_prioritize_after_to_task,
+                          t1.id, t1.id + 1, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertIsNone(self.app.ds.Task.query.get(t1.id + 1))
+
+    def test_remove_prioritize_after_removes_prioritize_after(self):
+
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t2.users.append(user)
+        t1.prioritize_after.append(t2)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(1, len(t1.prioritize_after))
+        self.assertEqual(1, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertTrue(t2 in t1.prioritize_after)
+        self.assertTrue(t1 in t2.prioritize_before)
+
+        # when
+        results = self.ll.do_remove_prioritize_after_from_task(t1.id, t2.id,
+                                                               user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertIsNotNone(results)
+        self.assertEqual([t1, t2], list(results))
+
+    def test_if_prioritize_after_already_removed_still_succeeds(self):
+
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t2.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+
+        # when
+        results = self.ll.do_remove_prioritize_after_from_task(t1.id, t2.id,
+                                                               user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertIsNotNone(results)
+        self.assertEqual([t1, t2], list(results))
+
+    def test_remove_prioritize_after_with_null_ids_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t2.users.append(user)
+        t1.prioritize_after.append(t2)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(1, len(t1.prioritize_after))
+        self.assertEqual(1, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertTrue(t2 in t1.prioritize_after)
+        self.assertTrue(t1 in t2.prioritize_before)
+
+        # expect
+        self.assertRaises(ValueError,
+                          self.ll.do_remove_prioritize_after_from_task,
+                          None, t2.id, user)
+
+        # expect
+        self.assertRaises(ValueError,
+                          self.ll.do_remove_prioritize_after_from_task,
+                          t1.id, None, user)
+
+        # expect
+        self.assertRaises(ValueError,
+                          self.ll.do_remove_prioritize_after_from_task,
+                          None, None, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(1, len(t1.prioritize_after))
+        self.assertEqual(1, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertTrue(t2 in t1.prioritize_after)
+        self.assertTrue(t1 in t2.prioritize_before)
+
+    def test_remove_prioritize_after_with_null_user_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t2.users.append(user)
+        t1.prioritize_after.append(t2)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(1, len(t1.prioritize_after))
+        self.assertEqual(1, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertTrue(t2 in t1.prioritize_after)
+        self.assertTrue(t1 in t2.prioritize_before)
+
+        # expect
+        self.assertRaises(ValueError,
+                          self.ll.do_remove_prioritize_after_from_task,
+                          t1.id, t2.id, None)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(1, len(t1.prioritize_after))
+        self.assertEqual(1, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertTrue(t2 in t1.prioritize_after)
+        self.assertTrue(t1 in t2.prioritize_before)
+
+    def test_rem_prioritize_after_user_unauthd_for_task_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t2.users.append(user)
+        t1.prioritize_after.append(t2)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+        # note that this situation shouldn't happen anyways. a task shouldn't
+        # be prioritized before another task unless both share a common set of
+        # one or more authorized users
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(1, len(t1.prioritize_after))
+        self.assertEqual(1, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertTrue(t2 in t1.prioritize_after)
+        self.assertTrue(t1 in t2.prioritize_before)
+
+        # expect
+        self.assertRaises(Forbidden,
+                          self.ll.do_remove_prioritize_after_from_task,
+                          t1.id, t2.id, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(1, len(t1.prioritize_after))
+        self.assertEqual(1, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertTrue(t2 in t1.prioritize_after)
+        self.assertTrue(t1 in t2.prioritize_before)
+
+    def test_remove_user_not_authd_for_prioritize_after_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        t1.prioritize_after.append(t2)
+        self.db.session.add(t1)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+        # note that this situation shouldn't happen anyways. a task shouldn't
+        # be prioritized before another task unless both share a common set of
+        # one or more authorized users
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(1, len(t1.prioritize_after))
+        self.assertEqual(1, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertTrue(t2 in t1.prioritize_after)
+        self.assertTrue(t1 in t2.prioritize_before)
+
+        # expect
+        self.assertRaises(Forbidden,
+                          self.ll.do_remove_prioritize_after_from_task,
+                          t1.id, t2.id, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(1, len(t1.prioritize_after))
+        self.assertEqual(1, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertTrue(t2 in t1.prioritize_after)
+        self.assertTrue(t1 in t2.prioritize_before)
+
+    def test_remove_prioritize_after_task_not_found_raises_exception(self):
+        # given
+        t2 = self.Task('t2')
+        user = self.User('name@example.com')
+        t2.users.append(user)
+        self.db.session.add(t2)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertIsNone(self.app.ds.Task.query.get(t2.id + 1))
+
+        # expect
+        self.assertRaises(NotFound,
+                          self.ll.do_remove_prioritize_after_from_task,
+                          t2.id + 1, t2.id, user)
+
+        # then
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertIsNone(self.app.ds.Task.query.get(t2.id+1))
+
+    def test_remove_prioritize_after_when_not_found_raises_exception(self):
+        # given
+        t1 = self.Task('t1')
+        user = self.User('name@example.com')
+        t1.users.append(user)
+        self.db.session.add(t1)
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertIsNone(self.app.ds.Task.query.get(t1.id + 1))
+
+        # expect
+        self.assertRaises(NotFound,
+                          self.ll.do_remove_prioritize_after_from_task,
+                          t1.id, t1.id + 1, user)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertIsNone(self.app.ds.Task.query.get(t1.id + 1))

--- a/tests/task_prioritize_tests.py
+++ b/tests/task_prioritize_tests.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+import unittest
+
+from werkzeug.exceptions import BadRequest, NotFound, Forbidden
+
+from tudor import generate_app
+
+
+class TaskPrioritizeTest(unittest.TestCase):
+    def setUp(self):
+        self.app = generate_app(db_uri='sqlite://')
+        self.db = self.app.ds.db
+        self.db.create_all()
+        self.Task = self.app.Task
+
+    def test_setting_task_as_before_sets_other_task_as_after(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+
+        # when
+        t1.prioritize_before.append(t2)
+
+        # then
+        self.assertEqual(1, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(1, len(t2.prioritize_after))
+        self.assertTrue(t2 in t1.prioritize_before)
+        self.assertTrue(t1 in t2.prioritize_after)
+
+    def test_setting_task_as_after_sets_other_task_as_before(self):
+        # given
+        t1 = self.Task('t1')
+        t2 = self.Task('t2')
+
+        # precondition
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(0, len(t1.prioritize_after))
+        self.assertEqual(0, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+
+        # when
+        t1.prioritize_after.append(t2)
+
+        # then
+        self.assertEqual(0, len(t1.prioritize_before))
+        self.assertEqual(1, len(t1.prioritize_after))
+        self.assertEqual(1, len(t2.prioritize_before))
+        self.assertEqual(0, len(t2.prioritize_after))
+        self.assertTrue(t2 in t1.prioritize_after)
+        self.assertTrue(t1 in t2.prioritize_before)

--- a/tudor.py
+++ b/tudor.py
@@ -960,6 +960,102 @@ def generate_app(db_uri=DEFAULT_TUDOR_DB_URI, ds_factory=None,
             request.args.get('next_url') or
             url_for('view_task', id=task_id)))
 
+    @app.route('/task/<int:task_id>/add_prioritize_before',
+               methods=['GET', 'POST'],
+               defaults={'prioritize_before_id': None})
+    @app.route('/task/<int:task_id>/add_prioritize_before/',
+               methods=['GET', 'POST'],
+               defaults={'prioritize_before_id': None})
+    @app.route(
+        '/task/<int:task_id>/add_prioritize_before/<int:prioritize_before_id>',
+        methods=['GET', 'POST'])
+    @login_required
+    def add_prioritize_before_to_task(task_id, prioritize_before_id):
+        if prioritize_before_id is None or prioritize_before_id == '':
+            prioritize_before_id = get_form_or_arg('prioritize_before_id')
+        if prioritize_before_id is None or prioritize_before_id == '':
+            return (redirect(request.args.get('next') or
+                             request.args.get('next_url') or
+                             url_for('view_task', id=task_id)))
+
+        ll.do_add_prioritize_before_to_task(task_id, prioritize_before_id,
+                                            current_user)
+        db.session.commit()
+
+        return (redirect(
+            request.args.get('next') or
+            request.args.get('next_url') or
+            url_for('view_task', id=task_id)))
+
+    @app.route('/task/<int:task_id>/remove_prioritize_before',
+               methods=['GET', 'POST'],
+               defaults={'prioritize_before_id': None})
+    @app.route('/task/<int:task_id>/remove_prioritize_before/',
+               methods=['GET', 'POST'],
+               defaults={'prioritize_before_id': None})
+    @app.route(
+        '/task/<int:task_id>/remove_prioritize_before/'
+        '<int:prioritize_before_id>',
+        methods=['GET', 'POST'])
+    def remove_prioritize_before_from_task(task_id, prioritize_before_id):
+        if prioritize_before_id is None:
+            prioritize_before_id = get_form_or_arg('prioritize_before_id')
+
+        ll.do_remove_prioritize_before_from_task(task_id, prioritize_before_id,
+                                                 current_user)
+        db.session.commit()
+
+        return (redirect(
+            request.args.get('next') or
+            request.args.get('next_url') or
+            url_for('view_task', id=task_id)))
+
+    @app.route('/task/<int:task_id>/add_prioritize_after',
+               methods=['GET', 'POST'], defaults={'prioritize_after_id': None})
+    @app.route('/task/<int:task_id>/add_prioritize_after/',
+               methods=['GET', 'POST'], defaults={'prioritize_after_id': None})
+    @app.route(
+        '/task/<int:task_id>/add_prioritize_after/<int:prioritize_after_id>',
+        methods=['GET', 'POST'])
+    @login_required
+    def add_prioritize_after_to_task(task_id, prioritize_after_id):
+        if prioritize_after_id is None or prioritize_after_id == '':
+            prioritize_after_id = get_form_or_arg('prioritize_after_id')
+        if prioritize_after_id is None or prioritize_after_id == '':
+            return (redirect(request.args.get('next') or
+                             request.args.get('next_url') or
+                             url_for('view_task', id=task_id)))
+
+        ll.do_add_prioritize_after_to_task(task_id, prioritize_after_id,
+                                           current_user)
+        db.session.commit()
+
+        return (redirect(
+            request.args.get('next') or
+            request.args.get('next_url') or
+            url_for('view_task', id=task_id)))
+
+    @app.route('/task/<int:task_id>/remove_prioritize_after',
+               methods=['GET', 'POST'], defaults={'prioritize_after_id': None})
+    @app.route('/task/<int:task_id>/remove_prioritize_after/',
+               methods=['GET', 'POST'], defaults={'prioritize_after_id': None})
+    @app.route(
+        '/task/<int:task_id>/remove_prioritize_after/'
+        '<int:prioritize_after_id>',
+        methods=['GET', 'POST'])
+    def remove_prioritize_after_from_task(task_id, prioritize_after_id):
+        if prioritize_after_id is None:
+            prioritize_after_id = get_form_or_arg('prioritize_after_id')
+
+        ll.do_remove_prioritize_after_from_task(task_id, prioritize_after_id,
+                                                current_user)
+        db.session.commit()
+
+        return (redirect(
+            request.args.get('next') or
+            request.args.get('next_url') or
+            url_for('view_task', id=task_id)))
+
     @app.template_filter(name='gfm')
     def render_gfm(s):
         output = markdown.markdown(s, extensions=['gfm'])


### PR DESCRIPTION
See https://issues.re.metaindu.com/task/1457

This PR adds a prioritization relationship between tasks, such that one task can be said to be more important than another. This is different than a dependency relationship, in that prioritization reflects user desires rather than requirements of the tasks themselves. Typically, the prioritization relationship will be between sibling tasks (with the same parent), or between top-level tasks (with no parent).

This PR includes a DB schema change.