### PR TITLE
Use unicode on all logging calls.

### DIFF
--- a/logging_util.py
+++ b/logging_util.py
@@ -5,9 +5,9 @@ config_was_set = False
 
 logging.basicConfig(
     level=logging.INFO,
-    format='%(relativeCreated)d:%(levelname)s:%(name)s:%(funcName)s:'
-           # '%(pathname)s,%(lineno)d:'
-           ' %(message)s')
+    format=u'%(relativeCreated)d:%(levelname)s:%(name)s:%(funcName)s:'
+           # u'%(pathname)s,%(lineno)d:'
+           u' %(message)s')
 
 
 def get_logger_by_object(module, obj):

--- a/models/attachment.py
+++ b/models/attachment.py
@@ -104,7 +104,7 @@ class Attachment(Changeable, AttachmentBase):
                  lazy=None):
         super(Attachment, self).__init__(path, description, timestamp,
                                          filename)
-        self._logger.debug('Note.__init__ {}'.format(self))
+        self._logger.debug(u'Note.__init__ {}'.format(self))
 
         if lazy is None:
             lazy = {}
@@ -177,7 +177,7 @@ class Attachment(Changeable, AttachmentBase):
 
     def _populate_task(self):
         if self._task_lazy:
-            self._logger.debug('populating task from lazy {}'.format(self))
+            self._logger.debug(u'populating task from lazy {}'.format(self))
             value = self._task_lazy()
             self._task_lazy = None
             self.task = value

--- a/models/interlinking.py
+++ b/models/interlinking.py
@@ -46,7 +46,7 @@ class InterlinkedSet(collections.MutableSet):
         return self.set.__iter__()
 
     def append(self, item):
-        self._logger.debug('{}: {}'.format(self.c, item))
+        self._logger.debug(u'{}: {}'.format(self.c, item))
         self._populate()
         self.add(item)
 
@@ -68,7 +68,7 @@ class OneToManySet(InterlinkedSet):
     _logger = logging_util.get_logger_by_name(__name__, 'OneToManySet')
 
     def add(self, item):
-        self._logger.debug('{}: {}'.format(self.c, item))
+        self._logger.debug(u'{}: {}'.format(self.c, item))
         if item not in self:
             self.container._on_attr_changing(self.__change_field__, None)
             self._add(item)
@@ -77,7 +77,7 @@ class OneToManySet(InterlinkedSet):
                                             Changeable.OP_ADD, item)
 
     def discard(self, item):
-        self._logger.debug('{}: {}'.format(self.c, item))
+        self._logger.debug(u'{}: {}'.format(self.c, item))
         if item in self:
             self.container._on_attr_changing(self.__change_field__, None)
             self._discard(item)
@@ -90,7 +90,7 @@ class ManyToManySet(InterlinkedSet):
     _logger = logging_util.get_logger_by_name(__name__, 'ManyToManySet')
 
     def add(self, item):
-        self._logger.debug('{}: {}'.format(self.c, item))
+        self._logger.debug(u'{}: {}'.format(self.c, item))
         if item not in self:
             self.container._on_attr_changing(self.__change_field__, None)
             self._add(item)
@@ -99,7 +99,7 @@ class ManyToManySet(InterlinkedSet):
                                             Changeable.OP_ADD, item)
 
     def discard(self, item):
-        self._logger.debug('{}: {}'.format(self.c, item))
+        self._logger.debug(u'{}: {}'.format(self.c, item))
         if item in self:
             self.container._on_attr_changing(self.__change_field__, None)
             self._discard(item)

--- a/models/note.py
+++ b/models/note.py
@@ -87,7 +87,7 @@ class Note(Changeable, NoteBase):
 
     def __init__(self, content, timestamp=None, lazy=None):
         super(Note, self).__init__(content, timestamp)
-        self._logger.debug('Note.__init__ {}'.format(self))
+        self._logger.debug(u'Note.__init__ {}'.format(self))
 
         if lazy is None:
             lazy = {}
@@ -137,7 +137,7 @@ class Note(Changeable, NoteBase):
 
     def _populate_task(self):
         if self._task_lazy:
-            self._logger.debug('populating task from lazy {}'.format(self))
+            self._logger.debug(u'populating task from lazy {}'.format(self))
             value = self._task_lazy()
             self._task_lazy = None
             self.task = value

--- a/models/tag.py
+++ b/models/tag.py
@@ -99,7 +99,7 @@ class Tag(Changeable, TagBase):
     def id(self, value):
         if value != self._id:
             self._logger.debug(
-                '{}: {} -> {}'.format(self, self._id, value))
+                u'{}: {} -> {}'.format(self, self._id, value))
             self._on_attr_changing(self.FIELD_ID, self._id)
             self._id = value
             self._on_attr_changed(self.FIELD_ID, self.OP_SET, self._id)
@@ -112,7 +112,7 @@ class Tag(Changeable, TagBase):
     def value(self, value):
         if value != self._value:
             self._logger.debug(
-                '{}: {} -> {}'.format(self, self._value, value))
+                u'{}: {} -> {}'.format(self, self._value, value))
             self._on_attr_changing(self.FIELD_VALUE, self._value)
             self._value = value
             self._on_attr_changed(self.FIELD_VALUE, self.OP_SET, self._value)
@@ -125,7 +125,7 @@ class Tag(Changeable, TagBase):
     def description(self, value):
         if value != self._description:
             self._logger.debug(
-                '{}: {} -> {}'.format(self, self._description, value))
+                u'{}: {} -> {}'.format(self, self._description, value))
             self._on_attr_changing(self.FIELD_DESCRIPTION, self._description)
             self._description = value
             self._on_attr_changed(self.FIELD_DESCRIPTION, self.OP_SET,

--- a/models/tag.py
+++ b/models/tag.py
@@ -13,7 +13,7 @@ class TagBase(object):
     FIELD_TASKS = 'TASKS'
 
     def __init__(self, value, description=None):
-        self._logger.debug('TagBase.__init__ {}'.format(self))
+        self._logger.debug(u'TagBase.__init__ {}'.format(self))
         self.value = value
         self.description = description
 
@@ -28,7 +28,7 @@ class TagBase(object):
 
     def to_dict(self, fields=None):
 
-        self._logger.debug('{}'.format(self))
+        self._logger.debug(u'{}'.format(self))
 
         d = {}
         if fields is None or self.FIELD_ID in fields:
@@ -46,7 +46,7 @@ class TagBase(object):
     @classmethod
     def from_dict(cls, d, lazy=None):
         logger = cls._logger
-        logger.debug('d: {}'.format(d))
+        logger.debug(u'd: {}'.format(d))
 
         tag_id = d.get('id', None)
         value = d.get('value')
@@ -58,11 +58,11 @@ class TagBase(object):
         if not lazy:
             if 'tasks' in d:
                 assign(tag.tasks, d['tasks'])
-        logger.debug('tag: {}'.format(tag))
+        logger.debug(u'tag: {}'.format(tag))
         return tag
 
     def update_from_dict(self, d):
-        self._logger.debug('{}: {}'.format(self, d))
+        self._logger.debug(u'{}: {}'.format(self, d))
         if 'id' in d and d['id'] is not None:
             self.id = d['id']
         if 'value' in d:
@@ -84,7 +84,7 @@ class Tag(Changeable, TagBase):
 
     def __init__(self, value, description=None, lazy=None):
         super(Tag, self).__init__(value=value, description=description)
-        self._logger.debug('Tag.__init__ {}'.format(self))
+        self._logger.debug(u'Tag.__init__ {}'.format(self))
 
         if lazy is None:
             lazy = {}

--- a/models/task.py
+++ b/models/task.py
@@ -320,7 +320,7 @@ class Task(Changeable, TaskBase):
     def is_deleted(self, value):
         if value != self._is_deleted:
             self._logger.debug(
-                '{}: {} -> {}'.format(self, self.is_deleted, value))
+                u'{}: {} -> {}'.format(self, self.is_deleted, value))
             self._on_attr_changing(self.FIELD_IS_DELETED, self._is_deleted)
             self._is_deleted = value
             self._on_attr_changed(self.FIELD_IS_DELETED, self.OP_SET,
@@ -334,7 +334,7 @@ class Task(Changeable, TaskBase):
     def order_num(self, value):
         if value != self._order_num:
             self._logger.debug(
-                '{}: {} -> {}'.format(self, self.order_num, value))
+                u'{}: {} -> {}'.format(self, self.order_num, value))
             self._on_attr_changing(self.FIELD_ORDER_NUM, self._order_num)
             self._order_num = value
             self._on_attr_changed(self.FIELD_ORDER_NUM, self.OP_SET,
@@ -348,7 +348,7 @@ class Task(Changeable, TaskBase):
     def deadline(self, value):
         if value != self._deadline:
             self._logger.debug(
-                '{}: {} -> {}'.format(self, self.deadline, value))
+                u'{}: {} -> {}'.format(self, self.deadline, value))
             self._on_attr_changing(self.FIELD_DEADLINE, self._deadline)
             self._deadline = value
             self._on_attr_changed(self.FIELD_DEADLINE, self.OP_SET,
@@ -362,8 +362,8 @@ class Task(Changeable, TaskBase):
     def expected_duration_minutes(self, value):
         if value != self._expected_duration_minutes:
             self._logger.debug(
-                '{}: {} -> {}'.format(self, self.expected_duration_minutes,
-                                      value))
+                u'{}: {} -> {}'.format(self, self.expected_duration_minutes,
+                                       value))
             self._on_attr_changing(self.FIELD_EXPECTED_DURATION_MINUTES,
                                    self._expected_duration_minutes)
             self._expected_duration_minutes = value
@@ -378,7 +378,7 @@ class Task(Changeable, TaskBase):
     def expected_cost(self, value):
         if value != self._expected_cost:
             self._logger.debug(
-                '{}: {} -> {}'.format(self, self.expected_cost, value))
+                u'{}: {} -> {}'.format(self, self.expected_cost, value))
             self._on_attr_changing(self.FIELD_EXPECTED_COST,
                                    self._expected_cost)
             self._expected_cost = value

--- a/models/task.py
+++ b/models/task.py
@@ -36,7 +36,7 @@ class TaskBase(object):
                  is_deleted=False, deadline=None,
                  expected_duration_minutes=None, expected_cost=None,
                  is_public=False):
-        self._logger.debug('TaskBase.__init__ {}'.format(self))
+        self._logger.debug(u'TaskBase.__init__ {}'.format(self))
 
         self.summary = summary
         self.description = description
@@ -65,7 +65,7 @@ class TaskBase(object):
 
     def to_dict(self, fields=None):
 
-        self._logger.debug('{}'.format(self))
+        self._logger.debug(u'{}'.format(self))
 
         d = {}
         if fields is None or self.FIELD_ID in fields:
@@ -158,7 +158,7 @@ class TaskBase(object):
         return task
 
     def update_from_dict(self, d):
-        self._logger.debug('{}: {}'.format(self, d))
+        self._logger.debug(u'{}: {}'.format(self, d))
         if 'id' in d and d['id'] is not None:
             self.id = d['id']
         if 'summary' in d:
@@ -230,7 +230,7 @@ class Task(Changeable, TaskBase):
             summary, description, is_done, is_deleted, deadline,
             expected_duration_minutes, expected_cost, is_public)
 
-        self._logger.debug('Task.__init__ {}'.format(self))
+        self._logger.debug(u'Task.__init__ {}'.format(self))
 
         if lazy is None:
             lazy = {}
@@ -265,7 +265,7 @@ class Task(Changeable, TaskBase):
     @id.setter
     def id(self, value):
         if value != self._id:
-            self._logger.debug('{}: {} -> {}'.format(self, self.id, value))
+            self._logger.debug(u'{}: {} -> {}'.format(self, self.id, value))
             self._on_attr_changing(self.FIELD_ID, self._id)
             self._id = value
             self._on_attr_changed(self.FIELD_ID, self.OP_SET, self._id)
@@ -277,7 +277,7 @@ class Task(Changeable, TaskBase):
     @summary.setter
     def summary(self, value):
         if value != self._summary:
-            self._logger.debug('{}: {} -> {}'.format(
+            self._logger.debug(u'{}: {} -> {}'.format(
                 self, repr(self.summary), repr(value)))
             self._on_attr_changing(self.FIELD_SUMMARY, self._summary)
             self._summary = value
@@ -292,7 +292,7 @@ class Task(Changeable, TaskBase):
     def description(self, value):
         if value != self._description:
             self._logger.debug(
-                '{}: {} -> {}'.format(self, self.description, value))
+                u'{}: {} -> {}'.format(self, self.description, value))
             self._on_attr_changing(self.FIELD_DESCRIPTION, self._description)
             self._description = value
             self._on_attr_changed(self.FIELD_DESCRIPTION, self.OP_SET,
@@ -305,8 +305,8 @@ class Task(Changeable, TaskBase):
     @is_done.setter
     def is_done(self, value):
         if value != self._is_done:
-            self._logger.debug('{}: {} -> {}'.format(self, self.is_done,
-                                                     value))
+            self._logger.debug(u'{}: {} -> {}'.format(self, self.is_done,
+                                                      value))
             self._on_attr_changing(self.FIELD_IS_DONE, self._is_done)
             self._is_done = value
             self._on_attr_changed(self.FIELD_IS_DONE, self.OP_SET,
@@ -393,7 +393,7 @@ class Task(Changeable, TaskBase):
 
     def _populate_parent(self):
         if self._parent_lazy:
-            self._logger.debug('populating parent from lazy {}'.format(self))
+            self._logger.debug(u'populating parent from lazy {}'.format(self))
             value = self._parent_lazy()
             self._parent_lazy = None
             self.parent = value
@@ -405,11 +405,11 @@ class Task(Changeable, TaskBase):
 
     @parent.setter
     def parent(self, value):
-        self._logger.debug('{}'.format(self))
+        self._logger.debug(u'{}'.format(self))
         self._populate_parent()
         if value != self._parent:
             self._logger.debug(
-                '{}: {} -> {}'.format(self, self._parent, value))
+                u'{}: {} -> {}'.format(self, self._parent, value))
             self._on_attr_changing(self.FIELD_PARENT, self._parent)
             if self._parent is not None:
                 self._parent.children.discard(self)
@@ -462,7 +462,7 @@ class Task(Changeable, TaskBase):
     def is_public(self, value):
         if value != self._is_public:
             self._logger.debug(
-                '{}: {} -> {}'.format(self, self.is_public, value))
+                u'{}: {} -> {}'.format(self, self.is_public, value))
             self._on_attr_changing(self.FIELD_IS_PUBLIC,
                                    self._is_public)
             self._is_public = value
@@ -471,18 +471,18 @@ class Task(Changeable, TaskBase):
 
     def get_css_class(self):
         if self.is_deleted and self.is_done:
-            return 'done-deleted'
+            return u'done-deleted'
         if self.is_deleted:
-            return 'not-done-deleted'
+            return u'not-done-deleted'
         if self.is_done:
-            return 'done-not-deleted'
+            return u'done-not-deleted'
         return ''
 
     def get_css_class_attr(self):
         cls = self.get_css_class()
         if cls:
-            return ' class="{}" '.format(cls)
-        return ''
+            return u' class="{}" '.format(cls)
+        return u''
 
     def get_tag_values(self):
         for tag in self.tags:
@@ -492,13 +492,13 @@ class Task(Changeable, TaskBase):
         if self.expected_duration_minutes is None:
             return ''
         if self.expected_duration_minutes == 1:
-            return '1 minute'
-        return '{} minutes'.format(self.expected_duration_minutes)
+            return u'1 minute'
+        return u'{} minutes'.format(self.expected_duration_minutes)
 
     def get_expected_cost_for_viewing(self):
         if self.expected_cost is None:
             return ''
-        return '{:.2f}'.format(self.expected_cost)
+        return u'{:.2f}'.format(self.expected_cost)
 
     def is_user_authorized(self, user):
         return user in self.users

--- a/persistence_layer.py
+++ b/persistence_layer.py
@@ -151,7 +151,7 @@ class PersistenceLayer(object):
         self._domain_by_db = {}
 
     def add(self, domobj):
-        self._logger.debug('begin, domobj: {}'.format(domobj))
+        self._logger.debug(u'begin, domobj: {}'.format(domobj))
         if domobj in self._deleted_objects:
             raise Exception(
                 'The object has already been set to be deleted: {}'.format(
@@ -163,7 +163,7 @@ class PersistenceLayer(object):
         dbobj = self._get_db_object_from_domain_object_in_cache(domobj)
         if dbobj is None:
             dbobj = self._create_db_object_from_domain_object(domobj)
-        self._logger.debug('dbobj: {}'.format(dbobj))
+        self._logger.debug(u'dbobj: {}'.format(dbobj))
 
         self._update_db_object_from_domain_object(domobj)
 
@@ -172,10 +172,10 @@ class PersistenceLayer(object):
         self._changed_objects.add(domobj)
 
         self.db.session.add(dbobj)
-        self._logger.debug('end')
+        self._logger.debug(u'end')
 
     def delete(self, domobj):
-        self._logger.debug('begin, domobj: {}'.format(domobj))
+        self._logger.debug(u'begin, domobj: {}'.format(domobj))
         if domobj in self._added_objects:
             raise Exception(
                 'The object has been added but not yet committed: {}'.format(
@@ -187,17 +187,17 @@ class PersistenceLayer(object):
                 raise Exception(
                     'Untracked domain object: {} ({})'.format(domobj,
                                                               type(domobj)))
-        self._logger.debug('begin, dbobj: {}'.format(dbobj))
+        self._logger.debug(u'begin, dbobj: {}'.format(dbobj))
         if domobj not in self._changed_objects_original_values:
             self._changed_objects_original_values[domobj] = domobj.to_dict()
         self._deleted_objects.add(domobj)
 
         domobj.clear_relationships()
         self.db.session.delete(dbobj)
-        self._logger.debug('end')
+        self._logger.debug(u'end')
 
     def commit(self):
-        self._logger.debug('begin')
+        self._logger.debug(u'begin')
 
         added = list(self._added_objects)
         deleted = list(self._deleted_objects)
@@ -208,9 +208,9 @@ class PersistenceLayer(object):
             domobj.clear_relationships()
 
         ###############
-        self._logger.debug('committing the db session/transaction')
+        self._logger.debug(u'committing the db session/transaction')
         self.db.session.commit()
-        self._logger.debug('committed the db session/transaction')
+        self._logger.debug(u'committed the db session/transaction')
         ###############
 
         for domobj in added:
@@ -218,10 +218,10 @@ class PersistenceLayer(object):
 
         self._clear_affected_objects()
 
-        self._logger.debug('end')
+        self._logger.debug(u'end')
 
     def rollback(self):
-        self._logger.debug('begin')
+        self._logger.debug(u'begin')
         self.db.session.rollback()
         original_values = self._changed_objects_original_values.copy()
         for domobj, d in original_values.iteritems():
@@ -230,7 +230,7 @@ class PersistenceLayer(object):
         for domobj in deleted:
             self._update_domain_object_from_db_object(domobj)
         self._clear_affected_objects()
-        self._logger.debug('end')
+        self._logger.debug(u'end')
 
     def _clear_affected_objects(self):
         self._changed_objects.clear()
@@ -247,7 +247,7 @@ class PersistenceLayer(object):
                            Note, User, Option))
 
     def _get_db_object_from_domain_object(self, domobj):
-        self._logger.debug('begin, domobj: {}'.format(domobj))
+        self._logger.debug(u'begin, domobj: {}'.format(domobj))
         if not self._is_domain_object(domobj):
             raise Exception(
                 'Not a domain object: {} ({})'.format(domobj, type(domobj)))
@@ -256,11 +256,11 @@ class PersistenceLayer(object):
             dbobj = self._get_db_object_from_domain_object_by_id(domobj)
         if dbobj is None:
             dbobj = self._create_db_object_from_domain_object(domobj)
-        self._logger.debug('end')
+        self._logger.debug(u'end')
         return dbobj
 
     def _get_db_object_from_domain_object_in_cache(self, domobj):
-        self._logger.debug('begin, domobj: {}'.format(domobj))
+        self._logger.debug(u'begin, domobj: {}'.format(domobj))
         if domobj is None:
             raise ValueError('domobj cannot be None')
         if not self._is_domain_object(domobj):
@@ -268,14 +268,14 @@ class PersistenceLayer(object):
                 'Not a domain object: {} ({})'.format(domobj, type(domobj)))
 
         if domobj not in self._db_by_domain:
-            self._logger.debug('end (domobj not in cache)')
+            self._logger.debug(u'end (domobj not in cache)')
             return None
 
-        self._logger.debug('end')
+        self._logger.debug(u'end')
         return self._db_by_domain[domobj]
 
     def _get_db_object_from_domain_object_by_id(self, domobj):
-        self._logger.debug('begin, domobj: {}'.format(domobj))
+        self._logger.debug(u'begin, domobj: {}'.format(domobj))
         if domobj is None:
             raise ValueError('domobj cannot be None')
         if not self._is_domain_object(domobj):
@@ -283,7 +283,7 @@ class PersistenceLayer(object):
                 'Not a domain object: {} ({})'.format(domobj, type(domobj)))
 
         if domobj.id is None:
-            self._logger.debug('end (domobj.id is None)')
+            self._logger.debug(u'end (domobj.id is None)')
             return None
 
         if isinstance(domobj, Attachment):
@@ -301,15 +301,15 @@ class PersistenceLayer(object):
             dbobj = self._get_db_user(domobj.id)
 
         if dbobj is not None:
-            self._logger.debug('dbobj is not None')
+            self._logger.debug(u'dbobj is not None')
             self._domain_by_db[dbobj] = domobj
             self._db_by_domain[domobj] = dbobj
 
-        self._logger.debug('end')
+        self._logger.debug(u'end')
         return dbobj
 
     def _create_db_object_from_domain_object(self, domobj):
-        self._logger.debug('begin, domobj: {}'.format(domobj))
+        self._logger.debug(u'begin, domobj: {}'.format(domobj))
         if domobj is None:
             raise ValueError('domobj cannot be None')
         if not self._is_domain_object(domobj):
@@ -347,11 +347,11 @@ class PersistenceLayer(object):
         dbattrs_rel = self._db_attrs_from_domain_links(domattrs)
         dbobj.update_from_dict(dbattrs_rel)
 
-        self._logger.debug('end')
+        self._logger.debug(u'end')
         return dbobj
 
     def _get_domain_object_from_db_object(self, dbobj):
-        self._logger.debug('begin, dbobj: {}'.format(dbobj))
+        self._logger.debug(u'begin, dbobj: {}'.format(dbobj))
         if dbobj is None:
             return None
         if not self._is_db_object(dbobj):
@@ -362,11 +362,11 @@ class PersistenceLayer(object):
         if domobj is None:
             domobj = self._create_domain_object_from_db_object(dbobj)
 
-        self._logger.debug('end')
+        self._logger.debug(u'end')
         return domobj
 
     def _get_domain_object_from_db_object_in_cache(self, dbobj):
-        self._logger.debug('begin, dbobj: {}'.format(dbobj))
+        self._logger.debug(u'begin, dbobj: {}'.format(dbobj))
         if dbobj is None:
             raise ValueError('dbobj cannot be None')
         if not self._is_db_object(dbobj):
@@ -374,14 +374,14 @@ class PersistenceLayer(object):
                 'Not a db object: {} ({})'.format(dbobj, type(dbobj)))
 
         if dbobj not in self._domain_by_db:
-            self._logger.debug('end (dbobj not in cache)')
+            self._logger.debug(u'end (dbobj not in cache)')
             return None
 
-        self._logger.debug('end')
+        self._logger.debug(u'end')
         return self._domain_by_db[dbobj]
 
     def _create_domain_object_from_db_object(self, dbobj):
-        self._logger.debug('begin, dbobj: {}'.format(dbobj))
+        self._logger.debug(u'begin, dbobj: {}'.format(dbobj))
         if dbobj is None:
             raise ValueError('dbobj cannot be None')
         if not self._is_db_object(dbobj):
@@ -420,23 +420,23 @@ class PersistenceLayer(object):
         self._domain_by_db[dbobj] = domobj
         self._db_by_domain[domobj] = dbobj
 
-        self._logger.debug('end')
+        self._logger.debug(u'end')
         return domobj
 
     def _domain_attrs_from_db_all(self, d):
         if d is None:
             raise ValueError('d must not be None')
-        self._logger.debug('d: {}'.format(d))
+        self._logger.debug(u'd: {}'.format(d))
         d2 = {}
         self._domain_attrs_from_db_no_links(d, d2)
         self._domain_attrs_from_db_links(d, d2)
-        self._logger.debug('d2: {}'.format(d2))
+        self._logger.debug(u'd2: {}'.format(d2))
         return d2
 
     def _domain_attrs_from_db_no_links(self, d, d2=None):
         if d is None:
             raise ValueError('d must not be None')
-        self._logger.debug('d: {}'.format(d))
+        self._logger.debug(u'd: {}'.format(d))
 
         if d2 is None:
             d2 = {}
@@ -445,13 +445,13 @@ class PersistenceLayer(object):
             if attrname not in self._relational_attrs:
                 d2[attrname] = d[attrname]
 
-        self._logger.debug('d2: {}'.format(d2))
+        self._logger.debug(u'd2: {}'.format(d2))
         return d2
 
     def _domain_attrs_from_db_links(self, d, d2=None):
         if d is None:
             raise ValueError('d must not be None')
-        # self._logger.debug('d: {}'.format(d))
+        # self._logger.debug(u'd: {}'.format(d))
         if d2 is None:
             d2 = {}
         if 'parent' in d and d['parent'] is not None:
@@ -492,13 +492,13 @@ class PersistenceLayer(object):
                 d['attachments']]
         if 'task' in d and d['task'] is not None:
             d2['task'] = self._get_domain_object_from_db_object(d['task'])
-        self._logger.debug('d2: {}'.format(d2))
+        self._logger.debug(u'd2: {}'.format(d2))
         return d2
 
     def _domain_attrs_from_db_links_lazy(self, d, d2=None):
         if d is None:
             raise ValueError('d must not be None')
-        # self._logger.debug('d: {}'.format(d))
+        # self._logger.debug(u'd: {}'.format(d))
         if d2 is None:
             d2 = {}
         if 'parent' in d and d['parent'] is not None:
@@ -541,14 +541,14 @@ class PersistenceLayer(object):
         if 'task' in d and d['task'] is not None:
             d2['task'] = \
                 lambda: self._get_domain_object_from_db_object(d['task'])
-        self._logger.debug('d2: {}'.format(d2))
+        self._logger.debug(u'd2: {}'.format(d2))
         return d2
 
     def _update_domain_object_from_dict(self, domobj, d):
         self._logger.debug(
             'begin, domobj: {}, d: {}'.format(domobj, d))
         domobj.update_from_dict(d)
-        self._logger.debug('end')
+        self._logger.debug(u'end')
 
     def _update_domain_object_from_db_object(self, domobj, fields=None):
         if domobj is None:
@@ -559,28 +559,28 @@ class PersistenceLayer(object):
         self._logger.debug(
             'got db obj {} -> {}'.format(domobj, dbobj))
         d = dbobj.to_dict(fields)
-        self._logger.debug('got db attrs {} -> {}'.format(domobj, d))
+        self._logger.debug(u'got db attrs {} -> {}'.format(domobj, d))
         d = self._domain_attrs_from_db_all(d)
-        self._logger.debug('got dom attrs {} -> {}'.format(domobj, d))
+        self._logger.debug(u'got dom attrs {} -> {}'.format(domobj, d))
         domobj.update_from_dict(d)
         self._logger.debug(
             'updated dom obj {} -> {}'.format(domobj, dbobj))
-        self._logger.debug('end')
+        self._logger.debug(u'end')
 
     _relational_attrs = {'parent', 'children', 'tags', 'tasks', 'users',
                          'dependees', 'dependants', 'prioritize_before',
                          'prioritize_after', 'notes', 'attachments', 'task'}
 
     def _db_attrs_from_domain_all(self, d):
-        self._logger.debug('d: {}'.format(d))
+        self._logger.debug(u'd: {}'.format(d))
         d2 = {}
         self._db_attrs_from_domain_no_links(d, d2)
         self._db_attrs_from_domain_links(d, d2)
-        self._logger.debug('d2: {}'.format(d2))
+        self._logger.debug(u'd2: {}'.format(d2))
         return d2
 
     def _db_attrs_from_domain_no_links(self, d, d2=None):
-        self._logger.debug('d: {}'.format(d))
+        self._logger.debug(u'd: {}'.format(d))
 
         if d2 is None:
             d2 = {}
@@ -589,11 +589,11 @@ class PersistenceLayer(object):
             if attrname not in self._relational_attrs:
                 d2[attrname] = d[attrname]
 
-        self._logger.debug('d2: {}'.format(d2))
+        self._logger.debug(u'd2: {}'.format(d2))
         return d2
 
     def _db_attrs_from_domain_links(self, d, d2=None):
-        self._logger.debug('d: {}'.format(d))
+        self._logger.debug(u'd: {}'.format(d))
         if d2 is None:
             d2 = {}
         if 'parent' in d and d['parent'] is not None:
@@ -634,7 +634,7 @@ class PersistenceLayer(object):
             d2['attachments'] = [
                 self._get_db_object_from_domain_object(domobj) for domobj in
                 d['attachments']]
-        self._logger.debug('d2: {}'.format(d2))
+        self._logger.debug(u'd2: {}'.format(d2))
         return d2
 
     def _db_value_from_domain(self, field, value):
@@ -655,13 +655,13 @@ class PersistenceLayer(object):
         self._logger.debug(
             'got db obj {} -> {}'.format(domobj, dbobj))
         d = domobj.to_dict(fields)
-        self._logger.debug('got dom attrs {} -> {}'.format(domobj, d))
+        self._logger.debug(u'got dom attrs {} -> {}'.format(domobj, d))
         d = self._db_attrs_from_domain_all(d)
-        self._logger.debug('got db attrs {} -> {}'.format(domobj, d))
+        self._logger.debug(u'got db attrs {} -> {}'.format(domobj, d))
         dbobj.update_from_dict(d)
         self._logger.debug(
             'updated db obj {} -> {}'.format(domobj, dbobj))
-        self._logger.debug('end')
+        self._logger.debug(u'end')
 
     def _on_domain_object_attr_changing(self, domobj, field, value):
         self._logger.debug(
@@ -669,7 +669,7 @@ class PersistenceLayer(object):
                                                              value))
         if domobj not in self._changed_objects_original_values:
             self._changed_objects_original_values[domobj] = domobj.to_dict()
-        self._logger.debug('end')
+        self._logger.debug(u'end')
 
     def _on_domain_object_attr_changed(self, domobj, field, operation, value):
         self._logger.debug(
@@ -680,13 +680,13 @@ class PersistenceLayer(object):
         value2 = self._db_value_from_domain(field, value)
         dbobj.make_change(field, operation, value2)
 
-        self._logger.debug('end')
+        self._logger.debug(u'end')
 
     def _register_domain_object(self, domobj):
-        self._logger.debug('begin, domobj: {}'.format(domobj))
+        self._logger.debug(u'begin, domobj: {}'.format(domobj))
         domobj.register_changing_listener(self._on_domain_object_attr_changing)
         domobj.register_changed_listener(self._on_domain_object_attr_changed)
-        self._logger.debug('end')
+        self._logger.debug(u'end')
 
     def create_all(self):
         self.db.create_all()

--- a/persistence_layer.py
+++ b/persistence_layer.py
@@ -546,7 +546,7 @@ class PersistenceLayer(object):
 
     def _update_domain_object_from_dict(self, domobj, d):
         self._logger.debug(
-            'begin, domobj: {}, d: {}'.format(domobj, d))
+            u'begin, domobj: {}, d: {}'.format(domobj, d))
         domobj.update_from_dict(d)
         self._logger.debug(u'end')
 
@@ -554,17 +554,17 @@ class PersistenceLayer(object):
         if domobj is None:
             raise ValueError('domobj cannot be None')
         self._logger.debug(
-            'begin, domobj: {}, fields: {}'.format(domobj, fields))
+            u'begin, domobj: {}, fields: {}'.format(domobj, fields))
         dbobj = self._get_db_object_from_domain_object(domobj)
         self._logger.debug(
-            'got db obj {} -> {}'.format(domobj, dbobj))
+            u'got db obj {} -> {}'.format(domobj, dbobj))
         d = dbobj.to_dict(fields)
         self._logger.debug(u'got db attrs {} -> {}'.format(domobj, d))
         d = self._domain_attrs_from_db_all(d)
         self._logger.debug(u'got dom attrs {} -> {}'.format(domobj, d))
         domobj.update_from_dict(d)
         self._logger.debug(
-            'updated dom obj {} -> {}'.format(domobj, dbobj))
+            u'updated dom obj {} -> {}'.format(domobj, dbobj))
         self._logger.debug(u'end')
 
     _relational_attrs = {'parent', 'children', 'tags', 'tasks', 'users',
@@ -650,30 +650,30 @@ class PersistenceLayer(object):
         if domobj is None:
             raise ValueError('domobj cannot be None')
         self._logger.debug(
-            'begin, domobj: {}, fields: {}'.format(domobj, fields))
+            u'begin, domobj: {}, fields: {}'.format(domobj, fields))
         dbobj = self._get_db_object_from_domain_object(domobj)
         self._logger.debug(
-            'got db obj {} -> {}'.format(domobj, dbobj))
+            u'got db obj {} -> {}'.format(domobj, dbobj))
         d = domobj.to_dict(fields)
         self._logger.debug(u'got dom attrs {} -> {}'.format(domobj, d))
         d = self._db_attrs_from_domain_all(d)
         self._logger.debug(u'got db attrs {} -> {}'.format(domobj, d))
         dbobj.update_from_dict(d)
         self._logger.debug(
-            'updated db obj {} -> {}'.format(domobj, dbobj))
+            u'updated db obj {} -> {}'.format(domobj, dbobj))
         self._logger.debug(u'end')
 
     def _on_domain_object_attr_changing(self, domobj, field, value):
         self._logger.debug(
-            'begin, domobj: {}, field: {}, value: {}'.format(domobj, field,
-                                                             value))
+            u'begin, domobj: {}, field: {}, value: {}'.format(domobj, field,
+                                                              value))
         if domobj not in self._changed_objects_original_values:
             self._changed_objects_original_values[domobj] = domobj.to_dict()
         self._logger.debug(u'end')
 
     def _on_domain_object_attr_changed(self, domobj, field, operation, value):
         self._logger.debug(
-            'begin, domobj: {}, field: {}, op: {}, value: {}'.format(
+            u'begin, domobj: {}, field: {}, op: {}, value: {}'.format(
                 domobj, field, operation, value))
 
         dbobj = self._get_db_object_from_domain_object(domobj)

--- a/tests/persistence_layer/persistence_layer_tests.py
+++ b/tests/persistence_layer/persistence_layer_tests.py
@@ -728,12 +728,12 @@ class PersistenceLayerTagsTest(unittest.TestCase):
 class PersistenceLayerPaginatedTasksTest(unittest.TestCase):
     def setUp(self):
         self._logger = logging.getLogger('test')
-        self._logger.debug('setUp generate_app')
+        self._logger.debug(u'setUp generate_app')
         self.pl = generate_pl()
-        self._logger.debug('setUp create_all')
+        self._logger.debug(u'setUp create_all')
         self.pl.db.drop_all()
         self.pl.create_all()
-        self._logger.debug('setUp create objects')
+        self._logger.debug(u'setUp create objects')
 
         self.t1 = Task('t1')
         self.t1.order_num = 11
@@ -747,12 +747,12 @@ class PersistenceLayerPaginatedTasksTest(unittest.TestCase):
         self.t5.order_num = 53
         self.tag1 = Tag('tag1')
         self.tag2 = Tag('tag2')
-        self._logger.debug('setUp connect objects')
+        self._logger.debug(u'setUp connect objects')
         self.t2.tags.add(self.tag1)
         self.t3.tags.add(self.tag1)
         self.t3.tags.add(self.tag2)
         self.t4.tags.add(self.tag1)
-        self._logger.debug('setUp add objects')
+        self._logger.debug(u'setUp add objects')
         self.pl.add(self.t1)
         self.pl.add(self.t2)
         self.pl.add(self.t3)
@@ -760,10 +760,10 @@ class PersistenceLayerPaginatedTasksTest(unittest.TestCase):
         self.pl.add(self.t5)
         self.pl.add(self.tag1)
         self.pl.add(self.tag2)
-        self._logger.debug('setUp commit')
+        self._logger.debug(u'setUp commit')
         self.pl.commit()
 
-        self._logger.debug('setUp finished')
+        self._logger.debug(u'setUp finished')
 
     def test_get_paginated_tasks_tasks_per_page_returns_that_number_1(self):
         # when
@@ -868,54 +868,54 @@ class PersistenceLayerPaginatedTasksTest(unittest.TestCase):
 
     def test_get_paginated_tasks_filtered_by_tag_tag1_page_1(self):
         # when
-        self._logger.debug('when')
+        self._logger.debug(u'when')
         tasks = self.pl.get_tasks(tags_contains=self.tag1)
         # then
-        self._logger.debug('then')
+        self._logger.debug(u'then')
         tasks2 = set(tasks)
         self.assertEqual({self.t2, self.t3, self.t4}, tasks2)
         # when
-        self._logger.debug('when')
+        self._logger.debug(u'when')
         count = self.pl.count_tasks(tags_contains=self.tag1)
         # then
-        self._logger.debug('then')
+        self._logger.debug(u'then')
         self.assertEqual(3, count)
         # expect
-        self._logger.debug('expect')
+        self._logger.debug(u'expect')
         self.assertEqual(3, self.pl.count_tasks(tags_contains=self.tag1))
         # expect
-        self._logger.debug('expect')
+        self._logger.debug(u'expect')
         self.assertEqual(3, self.pl.count_tasks(tags_contains=self.tag1))
         # expect
-        self._logger.debug('expect')
+        self._logger.debug(u'expect')
         self.assertEqual(3, self.pl.count_tasks(tags_contains=self.tag1))
 
         # when
-        self._logger.debug('when')
+        self._logger.debug(u'when')
         pager = self.pl.get_paginated_tasks(page_num=1, tasks_per_page=2,
                                             tags_contains=self.tag1)
         # then
-        self._logger.debug('then 1')
+        self._logger.debug(u'then 1')
         self.assertIsNotNone(pager)
-        self._logger.debug('then 2')
+        self._logger.debug(u'then 2')
         self.assertEqual(1, pager.page)
-        self._logger.debug('then 3')
+        self._logger.debug(u'then 3')
         self.assertEqual(2, pager.per_page)
-        self._logger.debug('then 4')
+        self._logger.debug(u'then 4')
         self.assertEqual(3, pager.total)
-        self._logger.debug('then 5')
+        self._logger.debug(u'then 5')
         items = list(pager.items)
-        self._logger.debug('then 6')
+        self._logger.debug(u'then 6')
         self.assertEqual(2, len(items))
-        self._logger.debug('then 7')
+        self._logger.debug(u'then 7')
         self.assertIn(self.tag1, items[0].tags)
-        self._logger.debug('then 8')
+        self._logger.debug(u'then 8')
         self.assertIn(items[0], {self.t2, self.t3, self.t4})
-        self._logger.debug('then 9')
+        self._logger.debug(u'then 9')
         self.assertIn(self.tag1, items[1].tags)
-        self._logger.debug('then 10')
+        self._logger.debug(u'then 10')
         self.assertIn(items[1], {self.t2, self.t3, self.t4})
-        self._logger.debug('when 11')
+        self._logger.debug(u'when 11')
 
     def test_get_paginated_tasks_filtered_by_tag_tag1_page_2(self):
         # when
@@ -3074,21 +3074,21 @@ class PersistenceLayerInternalsTest(unittest.TestCase):
     def test_adding_tag_to_task_also_adds_task_to_tag(self):
         # given
         logger = logging_util.get_logger_by_object(__name__, self)
-        logger.debug('before create task')
+        logger.debug(u'before create task')
         task = Task('task')
-        logger.debug('after create task')
-        logger.debug('before create tag')
+        logger.debug(u'after create task')
+        logger.debug(u'before create tag')
         tag = Tag('tag', description='a')
-        logger.debug('after create tag')
-        logger.debug('before add task')
+        logger.debug(u'after create tag')
+        logger.debug(u'before add task')
         self.pl.add(task)
-        logger.debug('after add task')
-        logger.debug('before add tag')
+        logger.debug(u'after add task')
+        logger.debug(u'before add tag')
         self.pl.add(tag)
-        logger.debug('after add tag')
-        logger.debug('before commit')
+        logger.debug(u'after add tag')
+        logger.debug(u'before commit')
         self.pl.commit()
-        logger.debug('after commit')
+        logger.debug(u'after commit')
 
 
 class PersistenceLayerDbOnlyDeletionTest(unittest.TestCase):


### PR DESCRIPTION
This PR changes all format strings used in logging calls to unicode strings( `''` to `u''`). When some logging calls format strings with unicode values from the db, it can cause a problem with the default ascii encoding.