### PR TITLE
Don't try to count the returned search results.

### DIFF
--- a/templates/search.t.html
+++ b/templates/search.t.html
@@ -9,7 +9,7 @@
     </form>
 </div>
 <div>
-{% if results and results.count() > 0 %}
+{% if results %}
     <hr>
 {% for task in results %}
     <p><a href="{{url_for('view_task', id=task.id)}}" {{ task.get_css_class_attr()|safe }}>{{task.summary}} ({{task.id}})</a></p>


### PR DESCRIPTION
There was an error in a previous PR: when extracting the `ViewLayer` class, we forgot to change the html template in line with the changing return value from the `LogicLayer.search` method. This PR fixes that oversight, so that searches don't result in 500's.