### PR TITLE
View task paging bug

### DIFF
--- a/logic_layer.py
+++ b/logic_layer.py
@@ -115,8 +115,9 @@ class LogicLayer(object):
 
         if parent_id is not None:
             parent = self.pl.get_task(parent_id)
-            if parent is not None and not TaskUserOps.is_user_authorized_or_admin(
-                    parent, current_user):
+            if (parent is not None and
+                    not TaskUserOps.is_user_authorized_or_admin(parent,
+                                                                current_user)):
                 raise werkzeug.exceptions.Forbidden()
             task.parent = parent
 
@@ -467,7 +468,8 @@ class LogicLayer(object):
         if task_to_move is None:
             raise werkzeug.exceptions.NotFound(
                 "No task object found for id '{}'".format(task_to_move_id))
-        if not TaskUserOps.is_user_authorized_or_admin(task_to_move, current_user):
+        if not TaskUserOps.is_user_authorized_or_admin(task_to_move,
+                                                       current_user):
             raise werkzeug.exceptions.Forbidden()
 
         target = self.pl.get_task(target_id)
@@ -1269,7 +1271,7 @@ class LogicLayer(object):
             raise werkzeug.exceptions.NotFound(
                 "No task found for the id '{}'".format(prioritize_before_id))
         if not TaskUserOps.is_user_authorized_or_admin(prioritize_before,
-                                                current_user):
+                                                       current_user):
             raise werkzeug.exceptions.Forbidden()
 
         if prioritize_before not in task.prioritize_before:
@@ -1299,7 +1301,7 @@ class LogicLayer(object):
             raise werkzeug.exceptions.NotFound(
                 "No task found for the id '{}'".format(prioritize_before_id))
         if not TaskUserOps.is_user_authorized_or_admin(prioritize_before,
-                                                current_user):
+                                                       current_user):
             raise werkzeug.exceptions.Forbidden()
 
         if prioritize_before in task.prioritize_before:

--- a/logic_layer.py
+++ b/logic_layer.py
@@ -177,7 +177,7 @@ class LogicLayer(object):
         return task
 
     def get_task_data(self, id, current_user, include_deleted=True,
-                      include_done=True):
+                      include_done=True, page_num=1, tasks_per_page=20):
         task = self.pl.get_task(id)
         # TODO: normalize access restrictions and exceptions in LogicLayer
         if task is None:
@@ -197,7 +197,8 @@ class LogicLayer(object):
                                              include_deleted=include_deleted,
                                              order_by_order_num=True,
                                              parent_id=task.id, paginate=True,
-                                             pager=_pager)
+                                             pager=_pager, page_num=page_num,
+                                             tasks_per_page=tasks_per_page)
         pager = _pager[0]
 
         hierarchy_sort = True

--- a/run_tests.py
+++ b/run_tests.py
@@ -71,7 +71,8 @@ from tests.logic_layer.load_no_hierarchy_exclude_non_public import *
 from tests.logic_layer.load_is_public_tests import LoadIsPublicTest, \
     LoadIsPublicRegularUserTest
 
-from tests.view_layer.route_tests import *
+from tests.view_layer.route_tests import RouteTest
+from tests.view_layer.task_tests import TaskTest
 
 
 def run():

--- a/tests/logic_layer/get_task_data_tests.py
+++ b/tests/logic_layer/get_task_data_tests.py
@@ -120,3 +120,267 @@ class GetTaskDataTest(unittest.TestCase):
         self.assertEqual(3, len(result))
 
     # TODO: is_done and is_deleted
+
+    def create_and_add_task(self, summary, order_num=None, parent=None,
+                            user=None):
+        task = Task(summary)
+        if order_num:
+            task.order_num = order_num
+        if parent:
+            task.parent = parent
+        if user:
+            task.users.add(user)
+        self.pl.add(task)
+        return task
+
+    def test_no_paging_info_specified_yields_page_one_with_twenty_items(self):
+        # given
+        self.pl.add(self.user)
+        t1 = self.create_and_add_task('t1', 1, self.task, self.user)
+        t2 = self.create_and_add_task('t2', 2, self.task, self.user)
+        t3 = self.create_and_add_task('t3', 3, self.task, self.user)
+        t4 = self.create_and_add_task('t4', 4, self.task, self.user)
+        t5 = self.create_and_add_task('t5', 5, self.task, self.user)
+        t6 = self.create_and_add_task('t6', 6, self.task, self.user)
+        t7 = self.create_and_add_task('t7', 7, self.task, self.user)
+        t8 = self.create_and_add_task('t8', 8, self.task, self.user)
+        t9 = self.create_and_add_task('t9', 9, self.task, self.user)
+        t10 = self.create_and_add_task('t10', 10, self.task, self.user)
+        t11 = self.create_and_add_task('t11', 11, self.task, self.user)
+        t12 = self.create_and_add_task('t12', 12, self.task, self.user)
+        t13 = self.create_and_add_task('t13', 13, self.task, self.user)
+        t14 = self.create_and_add_task('t14', 14, self.task, self.user)
+        t15 = self.create_and_add_task('t15', 15, self.task, self.user)
+        t16 = self.create_and_add_task('t16', 16, self.task, self.user)
+        t17 = self.create_and_add_task('t17', 17, self.task, self.user)
+        t18 = self.create_and_add_task('t18', 18, self.task, self.user)
+        t19 = self.create_and_add_task('t19', 19, self.task, self.user)
+        t20 = self.create_and_add_task('t20', 20, self.task, self.user)
+        t21 = self.create_and_add_task('t21', 21, self.task, self.user)
+        self.task.users.add(self.user)
+        self.pl.commit()
+        # when
+        result = self.ll.get_task_data(self.task.id, self.user)
+        # then
+        pager = result['pager']
+        self.assertEqual(1, pager.page)
+        self.assertEqual(2, pager.pages)
+        self.assertEqual(20, pager.per_page)
+
+    def test_page_num_one_yields_page_one(self):
+        # given
+        self.pl.add(self.user)
+        t1 = self.create_and_add_task('t1', 1, self.task, self.user)
+        t2 = self.create_and_add_task('t2', 2, self.task, self.user)
+        t3 = self.create_and_add_task('t3', 3, self.task, self.user)
+        t4 = self.create_and_add_task('t4', 4, self.task, self.user)
+        t5 = self.create_and_add_task('t5', 5, self.task, self.user)
+        t6 = self.create_and_add_task('t6', 6, self.task, self.user)
+        t7 = self.create_and_add_task('t7', 7, self.task, self.user)
+        t8 = self.create_and_add_task('t8', 8, self.task, self.user)
+        t9 = self.create_and_add_task('t9', 9, self.task, self.user)
+        t10 = self.create_and_add_task('t10', 10, self.task, self.user)
+        t11 = self.create_and_add_task('t11', 11, self.task, self.user)
+        t12 = self.create_and_add_task('t12', 12, self.task, self.user)
+        t13 = self.create_and_add_task('t13', 13, self.task, self.user)
+        t14 = self.create_and_add_task('t14', 14, self.task, self.user)
+        t15 = self.create_and_add_task('t15', 15, self.task, self.user)
+        t16 = self.create_and_add_task('t16', 16, self.task, self.user)
+        t17 = self.create_and_add_task('t17', 17, self.task, self.user)
+        t18 = self.create_and_add_task('t18', 18, self.task, self.user)
+        t19 = self.create_and_add_task('t19', 19, self.task, self.user)
+        t20 = self.create_and_add_task('t20', 20, self.task, self.user)
+        t21 = self.create_and_add_task('t21', 21, self.task, self.user)
+        self.task.users.add(self.user)
+        self.pl.commit()
+        # when
+        result = self.ll.get_task_data(self.task.id, self.user, page_num=1)
+        # then
+        pager = result['pager']
+        self.assertEqual(1, pager.page)
+        self.assertEqual(2, pager.pages)
+        self.assertEqual(20, pager.per_page)
+        self.assertEqual([t21, t20, t19, t18, t17, t16, t15, t14, t13, t12,
+                          t11, t10, t9, t8, t7, t6, t5, t4, t3, t2],
+                         pager.items)
+
+    def test_page_num_two_yields_page_two(self):
+        # given
+        self.pl.add(self.user)
+        t1 = self.create_and_add_task('t1', 1, self.task, self.user)
+        t2 = self.create_and_add_task('t2', 2, self.task, self.user)
+        t3 = self.create_and_add_task('t3', 3, self.task, self.user)
+        t4 = self.create_and_add_task('t4', 4, self.task, self.user)
+        t5 = self.create_and_add_task('t5', 5, self.task, self.user)
+        t6 = self.create_and_add_task('t6', 6, self.task, self.user)
+        t7 = self.create_and_add_task('t7', 7, self.task, self.user)
+        t8 = self.create_and_add_task('t8', 8, self.task, self.user)
+        t9 = self.create_and_add_task('t9', 9, self.task, self.user)
+        t10 = self.create_and_add_task('t10', 10, self.task, self.user)
+        t11 = self.create_and_add_task('t11', 11, self.task, self.user)
+        t12 = self.create_and_add_task('t12', 12, self.task, self.user)
+        t13 = self.create_and_add_task('t13', 13, self.task, self.user)
+        t14 = self.create_and_add_task('t14', 14, self.task, self.user)
+        t15 = self.create_and_add_task('t15', 15, self.task, self.user)
+        t16 = self.create_and_add_task('t16', 16, self.task, self.user)
+        t17 = self.create_and_add_task('t17', 17, self.task, self.user)
+        t18 = self.create_and_add_task('t18', 18, self.task, self.user)
+        t19 = self.create_and_add_task('t19', 19, self.task, self.user)
+        t20 = self.create_and_add_task('t20', 20, self.task, self.user)
+        t21 = self.create_and_add_task('t21', 21, self.task, self.user)
+        self.task.users.add(self.user)
+        self.pl.commit()
+        # when
+        result = self.ll.get_task_data(self.task.id, self.user, page_num=2)
+        # then
+        pager = result['pager']
+        self.assertEqual(2, pager.page)
+        self.assertEqual(2, pager.pages)
+        self.assertEqual(20, pager.per_page)
+        self.assertEqual([t1], pager.items)
+
+    def test_page_num_zero_raises(self):
+        # given
+        self.pl.add(self.user)
+        t1 = self.create_and_add_task('t1', 1, self.task, self.user)
+        t2 = self.create_and_add_task('t2', 2, self.task, self.user)
+        t3 = self.create_and_add_task('t3', 3, self.task, self.user)
+        t4 = self.create_and_add_task('t4', 4, self.task, self.user)
+        t5 = self.create_and_add_task('t5', 5, self.task, self.user)
+        t6 = self.create_and_add_task('t6', 6, self.task, self.user)
+        t7 = self.create_and_add_task('t7', 7, self.task, self.user)
+        t8 = self.create_and_add_task('t8', 8, self.task, self.user)
+        t9 = self.create_and_add_task('t9', 9, self.task, self.user)
+        t10 = self.create_and_add_task('t10', 10, self.task, self.user)
+        t11 = self.create_and_add_task('t11', 11, self.task, self.user)
+        t12 = self.create_and_add_task('t12', 12, self.task, self.user)
+        t13 = self.create_and_add_task('t13', 13, self.task, self.user)
+        t14 = self.create_and_add_task('t14', 14, self.task, self.user)
+        t15 = self.create_and_add_task('t15', 15, self.task, self.user)
+        t16 = self.create_and_add_task('t16', 16, self.task, self.user)
+        t17 = self.create_and_add_task('t17', 17, self.task, self.user)
+        t18 = self.create_and_add_task('t18', 18, self.task, self.user)
+        t19 = self.create_and_add_task('t19', 19, self.task, self.user)
+        t20 = self.create_and_add_task('t20', 20, self.task, self.user)
+        t21 = self.create_and_add_task('t21', 21, self.task, self.user)
+        self.task.users.add(self.user)
+        self.pl.commit()
+        result = None
+        # expect
+        self.assertRaises(
+            NotFound,
+            self.ll.get_task_data,
+            self.task.id, self.user, page_num=0)
+
+    def test_page_num_not_integer_raises(self):
+        # given
+        self.pl.add(self.user)
+        t1 = self.create_and_add_task('t1', 1, self.task, self.user)
+        t2 = self.create_and_add_task('t2', 2, self.task, self.user)
+        t3 = self.create_and_add_task('t3', 3, self.task, self.user)
+        t4 = self.create_and_add_task('t4', 4, self.task, self.user)
+        t5 = self.create_and_add_task('t5', 5, self.task, self.user)
+        t6 = self.create_and_add_task('t6', 6, self.task, self.user)
+        t7 = self.create_and_add_task('t7', 7, self.task, self.user)
+        t8 = self.create_and_add_task('t8', 8, self.task, self.user)
+        t9 = self.create_and_add_task('t9', 9, self.task, self.user)
+        t10 = self.create_and_add_task('t10', 10, self.task, self.user)
+        t11 = self.create_and_add_task('t11', 11, self.task, self.user)
+        t12 = self.create_and_add_task('t12', 12, self.task, self.user)
+        t13 = self.create_and_add_task('t13', 13, self.task, self.user)
+        t14 = self.create_and_add_task('t14', 14, self.task, self.user)
+        t15 = self.create_and_add_task('t15', 15, self.task, self.user)
+        t16 = self.create_and_add_task('t16', 16, self.task, self.user)
+        t17 = self.create_and_add_task('t17', 17, self.task, self.user)
+        t18 = self.create_and_add_task('t18', 18, self.task, self.user)
+        t19 = self.create_and_add_task('t19', 19, self.task, self.user)
+        t20 = self.create_and_add_task('t20', 20, self.task, self.user)
+        t21 = self.create_and_add_task('t21', 21, self.task, self.user)
+        self.task.users.add(self.user)
+        self.pl.commit()
+        result = None
+        # expect
+        self.assertRaises(
+            TypeError,
+            self.ll.get_task_data,
+            self.task.id, self.user, page_num='1')
+
+    def test_tasks_per_page_yields_that_many_per_page(self):
+        # given
+        self.pl.add(self.user)
+        t1 = self.create_and_add_task('t1', 1, self.task, self.user)
+        t2 = self.create_and_add_task('t2', 2, self.task, self.user)
+        t3 = self.create_and_add_task('t3', 3, self.task, self.user)
+        t4 = self.create_and_add_task('t4', 4, self.task, self.user)
+        t5 = self.create_and_add_task('t5', 5, self.task, self.user)
+        t6 = self.create_and_add_task('t6', 6, self.task, self.user)
+        self.task.users.add(self.user)
+        self.pl.commit()
+        # when
+        result = self.ll.get_task_data(self.task.id, self.user,
+                                       tasks_per_page=5)
+        # then
+        pager = result['pager']
+        self.assertEqual(1, pager.page)
+        self.assertEqual(2, pager.pages)
+        self.assertEqual(5, pager.per_page)
+        self.assertEqual([t6, t5, t4, t3, t2], pager.items)
+
+    def test_tasks_per_page_one_yields_one(self):
+        # given
+        self.pl.add(self.user)
+        t1 = self.create_and_add_task('t1', 1, self.task, self.user)
+        t2 = self.create_and_add_task('t2', 2, self.task, self.user)
+        t3 = self.create_and_add_task('t3', 3, self.task, self.user)
+        t4 = self.create_and_add_task('t4', 4, self.task, self.user)
+        t5 = self.create_and_add_task('t5', 5, self.task, self.user)
+        t6 = self.create_and_add_task('t6', 6, self.task, self.user)
+        self.task.users.add(self.user)
+        self.pl.commit()
+        # when
+        result = self.ll.get_task_data(self.task.id, self.user,
+                                       tasks_per_page=1)
+        # then
+        pager = result['pager']
+        self.assertEqual(1, pager.page)
+        self.assertEqual(6, pager.pages)
+        self.assertEqual(1, pager.per_page)
+        self.assertEqual([t6], pager.items)
+
+    def test_tasks_per_page_zero_yields_empty(self):
+        # given
+        self.pl.add(self.user)
+        t1 = self.create_and_add_task('t1', 1, self.task, self.user)
+        t2 = self.create_and_add_task('t2', 2, self.task, self.user)
+        t3 = self.create_and_add_task('t3', 3, self.task, self.user)
+        t4 = self.create_and_add_task('t4', 4, self.task, self.user)
+        t5 = self.create_and_add_task('t5', 5, self.task, self.user)
+        t6 = self.create_and_add_task('t6', 6, self.task, self.user)
+        self.task.users.add(self.user)
+        self.pl.commit()
+        # when
+        result = self.ll.get_task_data(self.task.id, self.user,
+                                       tasks_per_page=0)
+        # then
+        pager = result['pager']
+        self.assertEqual(1, pager.page)
+        self.assertEqual(0, pager.pages)
+        self.assertEqual(0, pager.per_page)
+        self.assertEqual([], pager.items)
+
+    def test_tasks_per_page_not_integer_raises(self):
+        # given
+        self.pl.add(self.user)
+        t1 = self.create_and_add_task('t1', 1, self.task, self.user)
+        t2 = self.create_and_add_task('t2', 2, self.task, self.user)
+        t3 = self.create_and_add_task('t3', 3, self.task, self.user)
+        t4 = self.create_and_add_task('t4', 4, self.task, self.user)
+        t5 = self.create_and_add_task('t5', 5, self.task, self.user)
+        t6 = self.create_and_add_task('t6', 6, self.task, self.user)
+        self.task.users.add(self.user)
+        self.pl.commit()
+        # expect
+        self.assertRaises(
+            ValueError,
+            self.ll.get_task_data,
+            self.task.id, self.user, tasks_per_page='20')

--- a/tests/view_layer/task_tests.py
+++ b/tests/view_layer/task_tests.py
@@ -1,0 +1,77 @@
+
+import unittest
+from mock import Mock
+from werkzeug.exceptions import NotFound
+
+from tudor import generate_app
+from view_layer import ViewLayer, DefaultRenderer
+from logic_layer import LogicLayer
+
+
+class TaskTest(unittest.TestCase):
+    def setUp(self):
+        self.ll = Mock(spec=LogicLayer)
+        self.return_value = {
+            'task': None,
+            'descendants': [],
+            'pager': None,
+        }
+        self.ll.get_task_data = Mock(return_value=self.return_value)
+        self.r = Mock(spec=DefaultRenderer)
+        self.vl = ViewLayer(self.ll, None, '', None, renderer=self.r)
+        self.app = generate_app(vl=self.vl, ll=self.ll, pl=None,
+                                configs={'LOGIN_DISABLED': True},
+                                secret_key='12345', disable_admin_check=True)
+        self.vl.app = self.app
+
+    def test_gets_task_data_from_logic_layer(self):
+        # given
+        request = Mock()
+        request.args = {}
+        request.cookies = {}
+        user = Mock()
+        TASK_ID = 1
+        # when
+        with self.app.app_context():
+            result = self.vl.task(request, user, TASK_ID)
+        # then
+        self.ll.get_task_data.assert_called_with(TASK_ID, user,
+                                                 include_deleted=None,
+                                                 include_done=None,
+                                                 page_num=1, tasks_per_page=20)
+        self.r.render_template.assert_called()
+
+    def test_page_num_not_int_defaults_to_one(self):
+        # given
+        request = Mock()
+        request.args = {'page': 'asdf'}
+        request.cookies = {}
+        user = Mock()
+        TASK_ID = 1
+        # when
+        with self.app.app_context():
+            result = self.vl.task(request, user, TASK_ID)
+        # then
+        self.ll.get_task_data.assert_called_with(TASK_ID, user,
+                                                 include_deleted=None,
+                                                 include_done=None,
+                                                 page_num=1, tasks_per_page=20)
+        self.r.render_template.assert_called()
+
+    def test_task_per_page_not_int_default_to_twenty(self):
+        # given
+        request = Mock()
+        request.args = {'per_page': 'asdf'}
+        request.cookies = {}
+        user = Mock()
+        TASK_ID = 1
+        # when
+        with self.app.app_context():
+            result = self.vl.task(request, user, TASK_ID)
+        # then
+        self.ll.get_task_data.assert_called_with(TASK_ID, user,
+                                                 include_deleted=None,
+                                                 include_done=None,
+                                                 page_num=1, tasks_per_page=20)
+        self.r.render_template.assert_called()
+

--- a/view_layer.py
+++ b/view_layer.py
@@ -205,9 +205,19 @@ class ViewLayer(object):
     def task(self, request, current_user, task_id):
         show_deleted = request.cookies.get('show_deleted')
         show_done = request.cookies.get('show_done')
+        try:
+            page_num = int(request.args.get('page', 1))
+        except Exception:
+            page_num = 1
+        try:
+            tasks_per_page = int(request.args.get('per_page', 20))
+        except Exception:
+            tasks_per_page = 20
         data = self.ll.get_task_data(task_id, current_user,
                                      include_deleted=show_deleted,
-                                     include_done=show_done)
+                                     include_done=show_done,
+                                     page_num=page_num,
+                                     tasks_per_page=tasks_per_page)
 
         return render_template('task.t.html',
                                task=data['task'],

--- a/view_layer.py
+++ b/view_layer.py
@@ -3,7 +3,7 @@ import itertools
 import re
 
 import flask
-from flask import make_response, render_template, url_for, redirect, flash
+from flask import url_for, redirect, flash
 from flask import jsonify, json
 from flask_login import login_user, logout_user
 from werkzeug.exceptions import NotFound, BadRequest
@@ -14,12 +14,31 @@ from conversions import int_from_str, money_from_str, bool_from_str
 from models.task_user_ops import TaskUserOps
 
 
+class DefaultRenderer(object):
+    def render_template(self, template_name, **kwargs):
+        from flask import render_template
+        return render_template(template_name, **kwargs)
+
+    def make_response(self, *args):
+        from flask import make_response
+        return make_response(*args)
+
+
 class ViewLayer(object):
-    def __init__(self, ll, app, upload_folder, pl):
+    def __init__(self, ll, app, upload_folder, pl, renderer=None):
         self.ll = ll
         self.app = app
         self.upload_folder = upload_folder
         self.pl = pl
+        if renderer is None:
+            renderer = DefaultRenderer()
+        self.renderer = renderer
+
+    def render_template(self, template_name, **kwargs):
+        return self.renderer.render_template(template_name, **kwargs)
+
+    def make_response(self, *args):
+        return self.renderer.make_response(*args)
 
     def get_form_or_arg(self, request, name):
         if name in request.form:
@@ -44,17 +63,17 @@ class ViewLayer(object):
                                       page_num=page_num,
                                       tasks_per_page=tasks_per_page)
 
-        resp = make_response(
-            render_template('index.t.html',
-                            show_deleted=data['show_deleted'],
-                            show_done=data['show_done'],
-                            cycle=itertools.cycle,
-                            user=current_user,
-                            tasks=data['tasks'],
-                            tags=data['all_tags'],
-                            pager=data['pager'],
-                            pager_link_page='index',
-                            pager_link_args={}))
+        resp = self.make_response(
+            self.render_template('index.t.html',
+                                 show_deleted=data['show_deleted'],
+                                 show_done=data['show_done'],
+                                 cycle=itertools.cycle,
+                                 user=current_user,
+                                 tasks=data['tasks'],
+                                 tags=data['all_tags'],
+                                 pager=data['pager'],
+                                 pager_link_page='index',
+                                 pager_link_args={}))
         return resp
 
     def hierarchy(self, request, current_user):
@@ -64,20 +83,20 @@ class ViewLayer(object):
         data = self.ll.get_index_hierarchy_data(show_deleted, show_done,
                                                 current_user)
 
-        resp = make_response(
-            render_template('hierarchy.t.html',
-                            show_deleted=data['show_deleted'],
-                            show_done=data['show_done'],
-                            cycle=itertools.cycle,
-                            user=current_user,
-                            tasks_h=data['tasks_h'],
-                            tags=data['all_tags']))
+        resp = self.make_response(
+            self.render_template('hierarchy.t.html',
+                                 show_deleted=data['show_deleted'],
+                                 show_done=data['show_done'],
+                                 cycle=itertools.cycle,
+                                 user=current_user,
+                                 tasks_h=data['tasks_h'],
+                                 tags=data['all_tags']))
         return resp
 
     def deadlines(self, request, current_user):
         data = self.ll.get_deadlines_data(current_user)
-        return make_response(
-            render_template(
+        return self.make_response(
+            self.render_template(
                 'deadlines.t.html',
                 cycle=itertools.cycle,
                 deadline_tasks=data['deadline_tasks']))
@@ -97,7 +116,7 @@ class ViewLayer(object):
 
         prev_url = self.get_form_or_arg(request, 'prev_url')
 
-        return render_template(
+        return self.render_template(
             'new_task.t.html', prev_url=prev_url, summary=summary,
             description=description, deadline=deadline, is_done=is_done,
             is_deleted=is_deleted, order_num=order_num,
@@ -200,7 +219,7 @@ class ViewLayer(object):
                 self.pl.delete(task)
             self.pl.commit()
             return redirect(request.args.get('next') or url_for('index'))
-        return render_template('purge.t.html')
+        return self.render_template('purge.t.html')
 
     def task(self, request, current_user, task_id):
         show_deleted = request.cookies.get('show_deleted')
@@ -219,18 +238,18 @@ class ViewLayer(object):
                                      page_num=page_num,
                                      tasks_per_page=tasks_per_page)
 
-        return render_template('task.t.html',
-                               task=data['task'],
-                               descendants=data['descendants'],
-                               cycle=itertools.cycle,
-                               show_deleted=show_deleted,
-                               show_done=show_done,
-                               pager=data['pager'],
-                               pager_link_page='view_task',
-                               pager_link_args={'id': task_id},
-                               current_user=current_user,
-                               ops=TaskUserOps,
-                               show_hierarchy=False)
+        return self.render_template('task.t.html',
+                                    task=data['task'],
+                                    descendants=data['descendants'],
+                                    cycle=itertools.cycle,
+                                    show_deleted=show_deleted,
+                                    show_done=show_done,
+                                    pager=data['pager'],
+                                    pager_link_page='view_task',
+                                    pager_link_args={'id': task_id},
+                                    current_user=current_user,
+                                    ops=TaskUserOps,
+                                    show_hierarchy=False)
 
     def task_hierarchy(self, request, current_user, task_id):
         show_deleted = request.cookies.get('show_deleted')
@@ -239,14 +258,14 @@ class ViewLayer(object):
                                                include_deleted=show_deleted,
                                                include_done=show_done)
 
-        return render_template('task.t.html',
-                               task=data['task'],
-                               descendants=data['descendants'],
-                               cycle=itertools.cycle,
-                               show_deleted=show_deleted,
-                               show_done=show_done,
-                               ops=TaskUserOps,
-                               show_hierarchy=True)
+        return self.render_template('task.t.html',
+                                    task=data['task'],
+                                    descendants=data['descendants'],
+                                    cycle=itertools.cycle,
+                                    show_deleted=show_deleted,
+                                    show_done=show_done,
+                                    ops=TaskUserOps,
+                                    show_hierarchy=True)
 
     def note_new_post(self, request, current_user):
         if 'task_id' not in request.form:
@@ -265,8 +284,8 @@ class ViewLayer(object):
 
         def render_get_response():
             data = self.ll.get_edit_task_data(task_id, current_user)
-            return render_template("edit_task.t.html", task=data['task'],
-                                   tag_list=data['tag_list'])
+            return self.render_template("edit_task.t.html", task=data['task'],
+                                        tag_list=data['tag_list'])
 
         if request.method == 'GET':
             return render_get_response()
@@ -420,8 +439,8 @@ class ViewLayer(object):
     def task_pick_user(self, request, current_user, task_id):
         task = self.ll.get_task(task_id, current_user)
         users = self.ll.get_users()
-        return render_template('pick_user.t.html', task=task, users=users,
-                               cycle=itertools.cycle)
+        return self.render_template('pick_user.t.html', task=task, users=users,
+                                    cycle=itertools.cycle)
 
     def task_authorize_user_user(self, request, current_user, task_id,
                                  user_id):
@@ -448,7 +467,7 @@ class ViewLayer(object):
 
     def login(self, request, current_user):
         if request.method == 'GET':
-            return render_template('login.t.html')
+            return self.render_template('login.t.html')
         email = request.form['email']
         password = request.form['password']
         user = self.pl.get_user_by_email(email)
@@ -475,8 +494,8 @@ class ViewLayer(object):
     def users(self, request, current_user):
         if request.method == 'GET':
             users = self.ll.get_users()
-            return render_template('list_users.t.html', users=users,
-                                   cycle=itertools.cycle)
+            return self.render_template('list_users.t.html', users=users,
+                                        cycle=itertools.cycle)
 
         email = request.form['email']
         is_admin = False
@@ -490,11 +509,11 @@ class ViewLayer(object):
 
     def users_user_get(self, request, current_user, user_id):
         user = self.ll.do_get_user_data(user_id, current_user)
-        return render_template('view_user.t.html', user=user)
+        return self.render_template('view_user.t.html', user=user)
 
     def show_hide_deleted(self, request, current_user):
         show_deleted = request.args.get('show_deleted')
-        resp = make_response(
+        resp = self.make_response(
             redirect(request.args.get('next') or url_for('index')))
         if show_deleted and show_deleted != '0':
             resp.set_cookie('show_deleted', '1')
@@ -504,7 +523,7 @@ class ViewLayer(object):
 
     def show_hide_done(self, request, current_user):
         show_done = request.args.get('show_done')
-        resp = make_response(
+        resp = self.make_response(
             redirect(request.args.get('next') or url_for('index')))
         if show_done and show_done != '0':
             resp.set_cookie('show_done', '1')
@@ -515,7 +534,7 @@ class ViewLayer(object):
     def options(self, request, current_user):
         if request.method == 'GET' or 'key' not in request.form:
             data = self.ll.get_view_options_data()
-            return render_template('options.t.html', options=data)
+            return self.render_template('options.t.html', options=data)
 
         key = request.form['key']
         value = ''
@@ -539,7 +558,7 @@ class ViewLayer(object):
 
     def export(self, request, current_user):
         if request.method == 'GET':
-            return render_template('export.t.html', results=None)
+            return self.render_template('export.t.html', results=None)
         types_to_export = set(k for k in request.form.keys() if
                               k in request.form and request.form[k] == 'all')
         results = self.ll.do_export_data(types_to_export)
@@ -547,7 +566,7 @@ class ViewLayer(object):
 
     def import_(self, request, current_user):
         if request.method == 'GET':
-            return render_template('import.t.html')
+            return self.render_template('import.t.html')
 
         f = request.files['file']
         if f is None or not f:
@@ -564,8 +583,8 @@ class ViewLayer(object):
     def task_crud(self, request, current_user):
         if request.method == 'GET':
             tasks = self.ll.get_task_crud_data(current_user)
-            return render_template('task_crud.t.html', tasks=tasks,
-                                   cycle=itertools.cycle)
+            return self.render_template('task_crud.t.html', tasks=tasks,
+                                        cycle=itertools.cycle)
 
         crud_data = {}
         for key in request.form.keys():
@@ -580,19 +599,19 @@ class ViewLayer(object):
 
     def tags(self, request, current_user):
         tags = self.ll.get_tags()
-        return render_template('list_tags.t.html', tags=tags,
-                               cycle=itertools.cycle)
+        return self.render_template('list_tags.t.html', tags=tags,
+                                    cycle=itertools.cycle)
 
     def tags_id_get(self, request, current_user, tag_id):
         data = self.ll.get_tag_data(tag_id, current_user)
-        return render_template('tag.t.html', tag=data['tag'],
-                               tasks=data['tasks'], cycle=itertools.cycle)
+        return self.render_template('tag.t.html', tag=data['tag'],
+                                    tasks=data['tasks'], cycle=itertools.cycle)
 
     def tags_id_edit(self, request, current_user, tag_id):
 
         def render_get_response():
             tag = self.ll.get_tag(tag_id)
-            return render_template("edit_tag.t.html", tag=tag)
+            return self.render_template("edit_tag.t.html", tag=tag)
 
         if request.method == 'GET':
             return render_get_response()
@@ -616,12 +635,12 @@ class ViewLayer(object):
                 request.args.get('next') or url_for('view_tag', id=tag.id))
 
         task = self.ll.get_task(task_id, current_user)
-        return render_template('convert_task_to_tag.t.html',
-                               task_id=task.id,
-                               tag_value=task.summary,
-                               tag_description=task.description,
-                               cycle=itertools.cycle,
-                               tasks=task.children)
+        return self.render_template('convert_task_to_tag.t.html',
+                                    task_id=task.id,
+                                    tag_value=task.summary,
+                                    tag_description=task.description,
+                                    cycle=itertools.cycle,
+                                    tasks=task.children)
 
     def search(self, request, current_user, search_query):
         if search_query is None and request.method == 'POST':
@@ -629,8 +648,8 @@ class ViewLayer(object):
 
         results = self.ll.search(search_query, current_user)
 
-        return render_template('search.t.html', query=search_query,
-                               results=results)
+        return self.render_template('search.t.html', query=search_query,
+                                    results=results)
 
     def task_id_add_dependee(self, request, current_user, task_id,
                              dependee_id):


### PR DESCRIPTION
The view-task page wasn't responding to the `per_page` and `page_num` query parameters, and was thus only ever showing the first page of child tasks. This PR fixes it so that all pages can be visited.