### PR TITLE
Make the radio's labels clickable.

### DIFF
--- a/static/tudor.css
+++ b/static/tudor.css
@@ -53,3 +53,8 @@ thead {
     text-decoration-line: overline underline;
     text-decoration-style: wavy;
 }
+
+.order-type-radio {
+    margin-bottom: 0;
+    font-weight: 400;
+}

--- a/templates/new_task.t.html
+++ b/templates/new_task.t.html
@@ -18,9 +18,24 @@
             <tr><td>Deadline</td><td><input type="text" name="deadline" value=""></td></tr>
             <tr><td>Done?</td><td><input type="checkbox" name="is_done" /></td></tr>
             <tr><td>Deleted?</td><td><input type="checkbox" name="is_deleted"/></td></tr>
-            <tr><td rowspan="3">Order:</td><td><input type="radio" name="order_type" value="bottom" checked/> Bottom of the list </td></tr>
-            <tr>                           <td><input type="radio" name="order_type" value="top" /> Top of the list</td></tr>
-            <tr>                           <td><input type="radio" name="order_type" value="order_num" /> Specific order_num: <input type="text" name="order_num" value="" /></td></tr>
+            <tr><td rowspan="3">Order:</td><td>
+                                            <label for="order_type_bottom" class="order-type-radio">
+                                                <input type="radio" name="order_type" value="bottom" id="order_type_bottom" checked/>
+                                                Bottom of the list
+                                            </label>
+                                           </td></tr>
+            <tr>                           <td>
+                                            <label for="order_type_top" class="order-type-radio">
+                                                <input type="radio" name="order_type" value="top" id="order_type_top" />
+                                                Top of the list
+                                            </label>
+                                           </td></tr>
+            <tr>                           <td>
+                                            <label for="order_type_order_num" class="order-type-radio">
+                                                <input type="radio" name="order_type" value="order_num" id="order_type_order_num" />
+                                                Specific order_num: <input type="text" name="order_num" value="" />
+                                            </label>
+                                           </td></tr>
             <tr><td>Expected duration (in minutes)</td><td><input type="text" name="expected_duration_minutes" value="" /></td></tr>
             <tr><td>Expected cost</td><td><input type="text" name="expected_cost" value="" /></td></tr>
             <tr><td>Parent ID</td><td><input type="text" name="parent_id" value="{{ parent_id if parent_id != None }}" /></td></tr>


### PR DESCRIPTION
This PR makes some minor markup and styling modifications. Previously, the radio buttons for choosing how to order newly-created tasks on the new-task page could be clicked, but the text next to them could not. This made for a very small clickable area. With these changes, the text next to each radio is now clickable and will cause the associated radio to be selected.