### PR TITLE
Fix export labels

### DIFF
--- a/static/tudor.css
+++ b/static/tudor.css
@@ -54,7 +54,7 @@ thead {
     text-decoration-style: wavy;
 }
 
-.order-type-radio {
+.radio-label {
     margin-bottom: 0;
     font-weight: 400;
 }

--- a/templates/export.t.html
+++ b/templates/export.t.html
@@ -15,42 +15,42 @@
             </thead>
             <tr class="odd">
                 <td>Tasks</td>
-                <td><label><input type="radio" name="tasks" value="all" checked/> Export all tasks</label></td>
-                <td><label><input type="radio" name="tasks" value="none"/> Do not export</label></td>
+                <td><label class="radio-label"><input type="radio" name="tasks" value="all" checked/> Export all tasks</label></td>
+                <td><label class="radio-label"><input type="radio" name="tasks" value="none"/> Do not export</label></td>
                 <!--<td><input type="radio" name="tasks" value="choose"/>Choose which tasks to export</td>-->
             </tr>
             <tr class="even">
                 <td>Tags</td>
-                <td><label><input type="radio" name="tags" value="all" checked/> Export all tags</label></td>
-                <td><label><input type="radio" name="tags" value="none"/> Do not export</label></td>
+                <td><label class="radio-label"><input type="radio" name="tags" value="all" checked/> Export all tags</label></td>
+                <td><label class="radio-label"><input type="radio" name="tags" value="none"/> Do not export</label></td>
                 <!--<td><input type="radio" name="tags" value="choose"/>Choose which tags to export</td>-->
                 </td>
             </tr>
             <tr class="odd">
                 <td>Notes</td>
-                <td><label><input type="radio" name="notes" value="all" checked/> Export all notes</label></td>
-                <td><label><input type="radio" name="notes" value="none"/> Do not export</label></td>
+                <td><label class="radio-label"><input type="radio" name="notes" value="all" checked/> Export all notes</label></td>
+                <td><label class="radio-label"><input type="radio" name="notes" value="none"/> Do not export</label></td>
                 <!--<td><input type="radio" name="notes" value="choose"/>Choose which notes to export</td>-->
                 </td>
             </tr>
             <tr class="even">
                 <td>Attachments</td>
-                <td><label><input type="radio" name="attachments" value="all" checked/> Export all attachments</label></td>
-                <td><label><input type="radio" name="attachments" value="none"/> Do not export</label></td>
+                <td><label class="radio-label"><input type="radio" name="attachments" value="all" checked/> Export all attachments</label></td>
+                <td><label class="radio-label"><input type="radio" name="attachments" value="none"/> Do not export</label></td>
                 <!--<td><input type="radio" name="attachments" value="choose"/>Choose which attachments to export</td>-->
                 </td>
             </tr>
             <tr class="odd">
                 <td>Users</td>
-                <td><label><input type="radio" name="users" value="all"/> Export all users</label></td>
-                <td><label><input type="radio" name="users" value="none" checked/> Do not export</label></td>
+                <td><label class="radio-label"><input type="radio" name="users" value="all"/> Export all users</label></td>
+                <td><label class="radio-label"><input type="radio" name="users" value="none" checked/> Do not export</label></td>
                 <!--<td><input type="radio" name="users" value="choose"/>Choose which users to export</td>-->
                 </td>
             </tr>
             <tr class="odd">
                 <td>Options</td>
-                <td><label><input type="radio" name="options" value="all"/> Export all options</label></td>
-                <td><label><input type="radio" name="options" value="none" checked/> Do not export</label></td>
+                <td><label class="radio-label"><input type="radio" name="options" value="all"/> Export all options</label></td>
+                <td><label class="radio-label"><input type="radio" name="options" value="none" checked/> Do not export</label></td>
                 <!--<td><input type="radio" name="options" value="choose"/>Choose which options to export</td>-->
                 </td>
             </tr>

--- a/templates/export.t.html
+++ b/templates/export.t.html
@@ -15,42 +15,42 @@
             </thead>
             <tr class="odd">
                 <td>Tasks</td>
-                <td><input type="radio" name="tasks" value="all" checked/>Export all tasks</td>
-                <td><input type="radio" name="tasks" value="none"/>Do not export</td>
+                <td><label><input type="radio" name="tasks" value="all" checked/> Export all tasks</label></td>
+                <td><label><input type="radio" name="tasks" value="none"/> Do not export</label></td>
                 <!--<td><input type="radio" name="tasks" value="choose"/>Choose which tasks to export</td>-->
             </tr>
             <tr class="even">
                 <td>Tags</td>
-                <td><input type="radio" name="tags" value="all" checked/>Export all tags</td>
-                <td><input type="radio" name="tags" value="none"/>Do not export</td>
+                <td><label><input type="radio" name="tags" value="all" checked/> Export all tags</label></td>
+                <td><label><input type="radio" name="tags" value="none"/> Do not export</label></td>
                 <!--<td><input type="radio" name="tags" value="choose"/>Choose which tags to export</td>-->
                 </td>
             </tr>
             <tr class="odd">
                 <td>Notes</td>
-                <td><input type="radio" name="notes" value="all" checked/>Export all notes</td>
-                <td><input type="radio" name="notes" value="none"/>Do not export</td>
+                <td><label><input type="radio" name="notes" value="all" checked/> Export all notes</label></td>
+                <td><label><input type="radio" name="notes" value="none"/> Do not export</label></td>
                 <!--<td><input type="radio" name="notes" value="choose"/>Choose which notes to export</td>-->
                 </td>
             </tr>
             <tr class="even">
                 <td>Attachments</td>
-                <td><input type="radio" name="attachments" value="all" checked/>Export all attachments</td>
-                <td><input type="radio" name="attachments" value="none"/>Do not export</td>
+                <td><label><input type="radio" name="attachments" value="all" checked/> Export all attachments</label></td>
+                <td><label><input type="radio" name="attachments" value="none"/> Do not export</label></td>
                 <!--<td><input type="radio" name="attachments" value="choose"/>Choose which attachments to export</td>-->
                 </td>
             </tr>
             <tr class="odd">
                 <td>Users</td>
-                <td><input type="radio" name="users" value="all"/>Export all users</td>
-                <td><input type="radio" name="users" value="none" checked/>Do not export</td>
+                <td><label><input type="radio" name="users" value="all"/> Export all users</label></td>
+                <td><label><input type="radio" name="users" value="none" checked/> Do not export</label></td>
                 <!--<td><input type="radio" name="users" value="choose"/>Choose which users to export</td>-->
                 </td>
             </tr>
             <tr class="odd">
                 <td>Options</td>
-                <td><input type="radio" name="options" value="all"/>Export all options</td>
-                <td><input type="radio" name="options" value="none" checked/>Do not export</td>
+                <td><label><input type="radio" name="options" value="all"/> Export all options</label></td>
+                <td><label><input type="radio" name="options" value="none" checked/> Do not export</label></td>
                 <!--<td><input type="radio" name="options" value="choose"/>Choose which options to export</td>-->
                 </td>
             </tr>

--- a/templates/new_task.t.html
+++ b/templates/new_task.t.html
@@ -19,19 +19,19 @@
             <tr><td>Done?</td><td><input type="checkbox" name="is_done" /></td></tr>
             <tr><td>Deleted?</td><td><input type="checkbox" name="is_deleted"/></td></tr>
             <tr><td rowspan="3">Order:</td><td>
-                                            <label for="order_type_bottom" class="order-type-radio">
+                                            <label for="order_type_bottom" class="radio-label">
                                                 <input type="radio" name="order_type" value="bottom" id="order_type_bottom" checked/>
                                                 Bottom of the list
                                             </label>
                                            </td></tr>
             <tr>                           <td>
-                                            <label for="order_type_top" class="order-type-radio">
+                                            <label for="order_type_top" class="radio-label">
                                                 <input type="radio" name="order_type" value="top" id="order_type_top" />
                                                 Top of the list
                                             </label>
                                            </td></tr>
             <tr>                           <td>
-                                            <label for="order_type_order_num" class="order-type-radio">
+                                            <label for="order_type_order_num" class="radio-label">
                                                 <input type="radio" name="order_type" value="order_num" id="order_type_order_num" />
                                                 Specific order_num: <input type="text" name="order_num" value="" />
                                             </label>


### PR DESCRIPTION
This PR, like [the previous one](#61 ), fixes the labels of radio buttons to make them clickable, for the "Export" page.