### PR TITLE
Gunicorn

### DIFF
--- a/gtudor.py
+++ b/gtudor.py
@@ -1,0 +1,6 @@
+from tudor import generate_app, TUDOR_DB_URI, TUDOR_UPLOAD_FOLDER, \
+    TUDOR_SECRET_KEY, TUDOR_ALLOWED_EXTENSIONS
+
+app = generate_app(db_uri=TUDOR_DB_URI, upload_folder=TUDOR_UPLOAD_FOLDER,
+                   secret_key=TUDOR_SECRET_KEY,
+                   allowed_extensions=TUDOR_ALLOWED_EXTENSIONS)

--- a/gtudor.py
+++ b/gtudor.py
@@ -1,6 +1,6 @@
-from tudor import generate_app, TUDOR_DB_URI, TUDOR_UPLOAD_FOLDER, \
-    TUDOR_SECRET_KEY, TUDOR_ALLOWED_EXTENSIONS
+from tudor import generate_app, Config
 
-app = generate_app(db_uri=TUDOR_DB_URI, upload_folder=TUDOR_UPLOAD_FOLDER,
-                   secret_key=TUDOR_SECRET_KEY,
-                   allowed_extensions=TUDOR_ALLOWED_EXTENSIONS)
+config = Config.from_environ()
+app = generate_app(db_uri=config.DB_URI, upload_folder=config.UPLOAD_FOLDER,
+                   secret_key=config.SECRET_KEY,
+                   allowed_extensions=config.ALLOWED_EXTENSIONS)

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -280,7 +280,7 @@ class ConfigFromEnvironTest(unittest.TestCase):
         self.assertEqual(8304, result.PORT)
         self.assertEqual('sqlite:////tmp/test.db', result.DB_URI)
         self.assertEqual('/tmp/tudor/uploads', result.UPLOAD_FOLDER)
-        self.assertEqual('txt,pdf,png,jpg,jpeg,gif', result.ALLsOWED_EXTENSIONS)
+        self.assertEqual('txt,pdf,png,jpg,jpeg,gif', result.ALLOWED_EXTENSIONS)
         self.assertIsNone(result.SECRET_KEY)
         self.assertIsNone(result.args)
 

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -271,7 +271,7 @@ class ConfigFromEnvironTest(unittest.TestCase):
         if 'TUDOR_SECRET_KEY' in os.environ:
             os.environ.pop('TUDOR_SECRET_KEY')
 
-    def from_environ_no_envvars_returns_defaults(self):
+    def test_from_environ_no_envvars_returns_defaults(self):
         # when
         result = Config.from_environ()
         # then
@@ -284,7 +284,7 @@ class ConfigFromEnvironTest(unittest.TestCase):
         self.assertIsNone(result.SECRET_KEY)
         self.assertIsNone(result.args)
 
-    def from_environ_with_envvars_returns_args(self):
+    def test_from_environ_with_envvars_returns_args(self):
         # given
 
         os.environ['TUDOR_DEBUG'] = True

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 from in_memory_persistence_layer import InMemoryPersistenceLayer
@@ -235,6 +236,60 @@ class ConfigTest(unittest.TestCase):
         result = Config(args=expected_result)
         # then
         self.assertIs(expected_result, result.args)
+
+
+class ConfigFromEnvironTest(unittest.TestCase):
+    def setUp(self):
+        os.environ.clear('TUDOR_DEBUG')
+        os.environ.clear('TUDOR_HOST')
+        os.environ.clear('TUDOR_PORT')
+        os.environ.clear('TUDOR_DB_URI')
+        os.environ.clear('TUDOR_UPLOAD_FOLDER')
+        os.environ.clear('TUDOR_ALLOWED_EXTENSIONS')
+        os.environ.clear('TUDOR_SECRET_KEY')
+
+    def tearDown(self):
+        os.environ.clear('TUDOR_DEBUG')
+        os.environ.clear('TUDOR_HOST')
+        os.environ.clear('TUDOR_PORT')
+        os.environ.clear('TUDOR_DB_URI')
+        os.environ.clear('TUDOR_UPLOAD_FOLDER')
+        os.environ.clear('TUDOR_ALLOWED_EXTENSIONS')
+        os.environ.clear('TUDOR_SECRET_KEY')
+
+    def from_environ_no_envvars_returns_defaults(self):
+        # when
+        result = Config.from_environ()
+        # then
+        self.assertIs(False, result.DEBUG)
+        self.assertEqual('127.0.0.1', result.HOST)
+        self.assertEqual(8304, result.PORT)
+        self.assertEqual('sqlite:////tmp/test.db', result.DB_URI)
+        self.assertEqual('/tmp/tudor/uploads', result.UPLOAD_FOLDER)
+        self.assertEqual('txt,pdf,png,jpg,jpeg,gif', result.ALLsOWED_EXTENSIONS)
+        self.assertIsNone(result.SECRET_KEY)
+        self.assertIsNone(result.args)
+
+    def from_environ_with_envvars_returns_args(self):
+        # given
+
+        os.environ['TUDOR_DEBUG'] = True
+        os.environ['TUDOR_HOST'] = '1.2.3.4'
+        os.environ['TUDOR_PORT'] = 12345
+        os.environ['TUDOR_DB_URI'] = 'sqlite://'
+        os.environ['TUDOR_UPLOAD_FOLDER'] = '/tmp/folder2'
+        os.environ['TUDOR_ALLOWED_EXTENSIONS'] = 'zip,exe'
+        os.environ['TUDOR_SECRET_KEY'] = '12345'
+        # when
+        result = Config.from_environ()
+        # then
+        self.assertIs(True, result.DEBUG)
+        self.assertEqual('1.2.3.4', result.HOST)
+        self.assertEqual(12345, result.PORT)
+        self.assertEqual('sqlite://', result.DB_URI)
+        self.assertEqual('/tmp/folder2', result.UPLOAD_FOLDER)
+        self.assertEqual('zip,exe', result.ALLOWED_EXTENSIONS)
+        self.assertEqual('12345', result.SECRET_KEY)
 
 
 class GetConfigFromCommandLineTest(unittest.TestCase):

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -240,22 +240,36 @@ class ConfigTest(unittest.TestCase):
 
 class ConfigFromEnvironTest(unittest.TestCase):
     def setUp(self):
-        os.environ.clear('TUDOR_DEBUG')
-        os.environ.clear('TUDOR_HOST')
-        os.environ.clear('TUDOR_PORT')
-        os.environ.clear('TUDOR_DB_URI')
-        os.environ.clear('TUDOR_UPLOAD_FOLDER')
-        os.environ.clear('TUDOR_ALLOWED_EXTENSIONS')
-        os.environ.clear('TUDOR_SECRET_KEY')
+        if 'TUDOR_DEBUG' in os.environ:
+            os.environ.pop('TUDOR_DEBUG')
+        if 'TUDOR_HOST' in os.environ:
+            os.environ.pop('TUDOR_HOST')
+        if 'TUDOR_PORT' in os.environ:
+            os.environ.pop('TUDOR_PORT')
+        if 'TUDOR_DB_URI' in os.environ:
+            os.environ.pop('TUDOR_DB_URI')
+        if 'TUDOR_UPLOAD_FOLDER' in os.environ:
+            os.environ.pop('TUDOR_UPLOAD_FOLDER')
+        if 'TUDOR_ALLOWED_EXTENSIONS' in os.environ:
+            os.environ.pop('TUDOR_ALLOWED_EXTENSIONS')
+        if 'TUDOR_SECRET_KEY' in os.environ:
+            os.environ.pop('TUDOR_SECRET_KEY')
 
     def tearDown(self):
-        os.environ.clear('TUDOR_DEBUG')
-        os.environ.clear('TUDOR_HOST')
-        os.environ.clear('TUDOR_PORT')
-        os.environ.clear('TUDOR_DB_URI')
-        os.environ.clear('TUDOR_UPLOAD_FOLDER')
-        os.environ.clear('TUDOR_ALLOWED_EXTENSIONS')
-        os.environ.clear('TUDOR_SECRET_KEY')
+        if 'TUDOR_DEBUG' in os.environ:
+            os.environ.pop('TUDOR_DEBUG')
+        if 'TUDOR_HOST' in os.environ:
+            os.environ.pop('TUDOR_HOST')
+        if 'TUDOR_PORT' in os.environ:
+            os.environ.pop('TUDOR_PORT')
+        if 'TUDOR_DB_URI' in os.environ:
+            os.environ.pop('TUDOR_DB_URI')
+        if 'TUDOR_UPLOAD_FOLDER' in os.environ:
+            os.environ.pop('TUDOR_UPLOAD_FOLDER')
+        if 'TUDOR_ALLOWED_EXTENSIONS' in os.environ:
+            os.environ.pop('TUDOR_ALLOWED_EXTENSIONS')
+        if 'TUDOR_SECRET_KEY' in os.environ:
+            os.environ.pop('TUDOR_SECRET_KEY')
 
     def from_environ_no_envvars_returns_defaults(self):
         # when

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -287,9 +287,9 @@ class ConfigFromEnvironTest(unittest.TestCase):
     def test_from_environ_with_envvars_returns_args(self):
         # given
 
-        os.environ['TUDOR_DEBUG'] = True
+        os.environ['TUDOR_DEBUG'] = str(True)
         os.environ['TUDOR_HOST'] = '1.2.3.4'
-        os.environ['TUDOR_PORT'] = 12345
+        os.environ['TUDOR_PORT'] = str(12345)
         os.environ['TUDOR_DB_URI'] = 'sqlite://'
         os.environ['TUDOR_UPLOAD_FOLDER'] = '/tmp/folder2'
         os.environ['TUDOR_ALLOWED_EXTENSIONS'] = 'zip,exe'

--- a/tudor.py
+++ b/tudor.py
@@ -53,6 +53,21 @@ class Config(object):
         self.SECRET_KEY = secret_key
         self.args = args
 
+    @staticmethod
+    def from_environ():
+        return Config(
+            debug=bool_from_str(
+                environ.get('TUDOR_DEBUG', DEFAULT_TUDOR_DEBUG)),
+            host=environ.get('TUDOR_HOST', DEFAULT_TUDOR_HOST),
+            port=int_from_str(environ.get('TUDOR_PORT', DEFAULT_TUDOR_PORT),
+                              DEFAULT_TUDOR_PORT),
+            db_uri=environ.get('TUDOR_DB_URI', DEFAULT_TUDOR_DB_URI),
+            upload_folder=environ.get('TUDOR_UPLOAD_FOLDER',
+                                      DEFAULT_TUDOR_UPLOAD_FOLDER),
+            allowed_extensions=environ.get('TUDOR_ALLOWED_EXTENSIONS',
+                                           DEFAULT_TUDOR_ALLOWED_EXTENSIONS),
+            secret_key=environ.get('TUDOR_SECRET_KEY'))
+
 
 def get_config_from_command_line(args, defaults):
     parser = argparse.ArgumentParser()
@@ -633,17 +648,7 @@ if __name__ == '__main__':
 
     default_config = Config()
 
-    env_config = Config(
-        debug=bool_from_str(environ.get('TUDOR_DEBUG', default_config.DEBUG)),
-        host=environ.get('TUDOR_HOST', default_config.HOST),
-        port=int_from_str(environ.get('TUDOR_PORT', default_config.PORT),
-                          default_config.PORT),
-        db_uri=environ.get('TUDOR_DB_URI', default_config.DB_URI),
-        upload_folder=environ.get('TUDOR_UPLOAD_FOLDER',
-                                  default_config.UPLOAD_FOLDER),
-        allowed_extensions=environ.get('TUDOR_ALLOWED_EXTENSIONS',
-                                       default_config.ALLOWED_EXTENSIONS),
-        secret_key=environ.get('TUDOR_SECRET_KEY'))
+    env_config = Config.from_environ()
 
     arg_config = get_config_from_command_line(sys.argv[1:], env_config)
 


### PR DESCRIPTION
This PR adds a module for running Tudor via [Gunicorn](http://gunicorn.org/). It should be used like so:
`gunicorn -b 127.0.0.1:8304 gtudor:app`

Since the `gunicorn` method by-passes the command-line argument parsing of `tudor.py`, the app can only be configure via command-line variables. Also, the `TUDOR_DEBUG`, `TUDOR_HOST`, and `TUDOR_PORT` environment variables will have no effect, since their values are used to control Flask's built-in runner, and `gunicorn` already takes care of the host and port.