### PR TITLE
Add a --profile cli arg that uses the werkzeug profiler middleware.

### DIFF
--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -326,6 +326,7 @@ class GetConfigFromCommandLineTest(unittest.TestCase):
                          result.ALLOWED_EXTENSIONS)
         self.assertEqual(self.env_configs.SECRET_KEY, result.SECRET_KEY)
         self.assertIsNotNone(result.args)
+        self.assertFalse(result.args.profile)
 
     def test_debug_arg_yields_debug(self):
         # when
@@ -477,3 +478,9 @@ class GetConfigFromCommandLineTest(unittest.TestCase):
         # then
         self.assertIsNotNone(result.args)
         self.assertTrue(result.args.test_db_conn)
+
+    def test_profile_arg_yields_profile(self):
+        # when
+        result = get_config_from_command_line(['--profile'], self.env_configs)
+        # then
+        self.assertTrue(result.args.profile)

--- a/tudor.py
+++ b/tudor.py
@@ -14,6 +14,7 @@ import markdown
 from functools import wraps
 import git
 from flask_sqlalchemy import SQLAlchemy
+from werkzeug.contrib.profiler import ProfilerMiddleware
 
 from conversions import bool_from_str, int_from_str
 from logic_layer import LogicLayer
@@ -101,6 +102,10 @@ def get_config_from_command_line(args, defaults):
     parser.add_argument('--test-db-conn', action='store_true',
                         help='Try to make a connection to the database. '
                              'Useful for diagnosing connection problems.')
+    parser.add_argument('--profile', action='store_true',
+                        help='Measure run time and print a table on STDOUT of '
+                             'how much time each function call took, at the '
+                             'end of each request.')
 
     args2 = parser.parse_args(args=args)
 
@@ -666,6 +671,10 @@ if __name__ == '__main__':
                        allowed_extensions=arg_config.ALLOWED_EXTENSIONS)
 
     args = arg_config.args
+
+    if args.profile:
+        app.config['PROFILE'] = True
+        app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[30])
 
     if args.create_db:
         print('Setting up the database')


### PR DESCRIPTION
This PR adds a `--profile` command-line argument that allows the app to be run with a profiler attached. The profiler will calculate how much time is spent in a function/method. It does this for each request, and prints out the results as a table, on STDERR.