### PR TITLE
Log everything

### DIFF
--- a/logic_layer.py
+++ b/logic_layer.py
@@ -99,6 +99,8 @@ class LogicLayer(object):
                         is_done=None, is_deleted=None, deadline=None,
                         expected_duration_minutes=None, expected_cost=None,
                         order_num=None, parent_id=None, is_public=None):
+        self._logger.debug('begin')
+        self._logger.debug('creating the new task')
         task = Task(
             summary=summary, description=description, is_done=is_done,
             is_deleted=is_deleted, deadline=deadline,
@@ -106,6 +108,7 @@ class LogicLayer(object):
             expected_cost=expected_cost, is_public=is_public)
 
         if order_num is None:
+            self._logger.debug('order_num not set, calculating')
             order_num = self.get_lowest_order_num()
             if order_num is not None:
                 order_num -= 2
@@ -115,23 +118,30 @@ class LogicLayer(object):
         task.order_num = order_num
 
         if parent_id is not None:
+            self._logger.debug('parent_id specified. looking it up (%d)',
+                               parent_id)
             parent = self.pl.get_task(parent_id)
             if (parent is not None and
                     not TaskUserOps.is_user_authorized_or_admin(parent,
                                                                 current_user)):
+                self._logger.error('User (%d) not authorized for parent (%d)',
+                                   current_user.id, parent_id)
                 raise werkzeug.exceptions.Forbidden()
             task.parent = parent
 
+        self._logger.debug('authorizing the current user for this task')
         task.users.append(current_user)
 
+        self._logger.debug('adding the task to the session')
         self.pl.add(task)
+        self._logger.debug('committing')
         self.pl.commit()
 
+        self._logger.debug('end')
         return task
 
     def get_lowest_order_num(self):
         self._logger.debug('getting lowest order task')
-        # self.pl._get_tasks_query(order_by=[[self.pl.ORDER_NUM, self.pl.ASCENDING]], limit=1)
         tasks = self.pl.get_tasks(
             order_by=[[self.pl.ORDER_NUM, self.pl.ASCENDING]], limit=1)
         self._logger.debug('rendering list')

--- a/logic_layer.py
+++ b/logic_layer.py
@@ -9,6 +9,7 @@ import werkzeug.exceptions
 from werkzeug.exceptions import Forbidden
 from werkzeug import secure_filename
 
+import logging_util
 from conversions import int_from_str, money_from_str
 from exception import UserCannotViewTaskException
 from models.task import Task
@@ -21,6 +22,7 @@ from models.user import User
 
 
 class LogicLayer(object):
+    _logger = logging_util.get_logger_by_name(__name__, 'LogicLayer')
 
     def __init__(self, upload_folder, allowed_extensions, pl):
         self.pl = pl
@@ -128,11 +130,18 @@ class LogicLayer(object):
         return task
 
     def get_lowest_order_num(self):
+        self._logger.debug('getting lowest order task')
+        # self.pl._get_tasks_query(order_by=[[self.pl.ORDER_NUM, self.pl.ASCENDING]], limit=1)
         tasks = self.pl.get_tasks(
             order_by=[[self.pl.ORDER_NUM, self.pl.ASCENDING]], limit=1)
+        self._logger.debug('rendering list')
         lowest_order_num_tasks = list(tasks)
+        self._logger.debug('checking list size')
         if len(lowest_order_num_tasks) > 0:
+            self._logger.debug('list size > 0, lowest order_num == %d',
+                               lowest_order_num_tasks[0].order_num)
             return lowest_order_num_tasks[0].order_num
+        self._logger.debug('list size == 0')
         return None
 
     def get_highest_order_num(self):

--- a/logic_layer.py
+++ b/logic_layer.py
@@ -124,7 +124,7 @@ class LogicLayer(object):
             if (parent is not None and
                     not TaskUserOps.is_user_authorized_or_admin(parent,
                                                                 current_user)):
-                self._logger.error('User (%d) not authorized for parent (%d)',
+                self._logger.debug('User (%d) not authorized for parent (%d)',
                                    current_user.id, parent_id)
                 raise werkzeug.exceptions.Forbidden()
             task.parent = parent

--- a/logic_layer.py
+++ b/logic_layer.py
@@ -145,11 +145,17 @@ class LogicLayer(object):
         return None
 
     def get_highest_order_num(self):
+        self._logger.debug('getting highest order task')
         tasks = self.pl.get_tasks(
             order_by=[[self.pl.ORDER_NUM, self.pl.DESCENDING]], limit=1)
+        self._logger.debug('rendering list')
         highest_order_num_tasks = list(tasks)
+        self._logger.debug('checking list size')
         if len(highest_order_num_tasks) > 0:
+            self._logger.debug('list size > 0, highest order_num == %d',
+                               highest_order_num_tasks[0].order_num)
             return highest_order_num_tasks[0].order_num
+        self._logger.debug('list size == 0')
         return None
 
     def task_set_done(self, id, current_user):

--- a/models/interlinking.py
+++ b/models/interlinking.py
@@ -11,6 +11,7 @@ class InterlinkedSet(collections.MutableSet):
     __attr_counterpart__ = None
 
     def __init__(self, container, lazy=None):
+        self._logger.debug('__init__')
         if container is None:
             raise ValueError('container cannot be None')
 
@@ -19,13 +20,16 @@ class InterlinkedSet(collections.MutableSet):
         self._lazy = lazy
 
     def __repr__(self):
+        self._logger.debug('__repr__')
         cls = type(self).__name__
         if self._lazy:
             return '{}(<lazy>)'.format(cls)
         return '{}({})'.format(cls, self.set)
 
     def _populate(self):
+        self._logger.debug('_populate')
         if self._lazy:
+            self._logger.debug('populating the collection')
             self.set.update(self._lazy)
             self._lazy = None
 
@@ -34,32 +38,39 @@ class InterlinkedSet(collections.MutableSet):
         return self.container
 
     def __len__(self):
+        self._logger.debug('__len__')
         self._populate()
         return len(self.set)
 
     def __contains__(self, item):
+        self._logger.debug('__contains__')
         self._populate()
         return self.set.__contains__(item)
 
     def __iter__(self):
+        self._logger.debug('__iter__')
         self._populate()
         return self.set.__iter__()
 
     def append(self, item):
+        self._logger.debug('append')
         self._logger.debug(u'%s: %s', self.c, item)
         self._populate()
         self.add(item)
 
     def __str__(self):
+        self._logger.debug('__str__')
         if self._lazy:
             return 'set(<lazy>)'
         return str(self.set)
 
     def _add(self, item):
+        self._logger.debug('_add')
         self._populate()
         self.set.add(item)
 
     def _discard(self, item):
+        self._logger.debug('_discard')
         self._populate()
         self.set.discard(item)
 
@@ -68,8 +79,10 @@ class OneToManySet(InterlinkedSet):
     _logger = logging_util.get_logger_by_name(__name__, 'OneToManySet')
 
     def add(self, item):
+        self._logger.debug('add')
         self._logger.debug(u'%s: %s', self.c, item)
         if item not in self:
+            self._logger.debug('adding the item')
             self.container._on_attr_changing(self.__change_field__, None)
             self._add(item)
             setattr(item, self.__attr_counterpart__, self.container)
@@ -77,8 +90,10 @@ class OneToManySet(InterlinkedSet):
                                             Changeable.OP_ADD, item)
 
     def discard(self, item):
+        self._logger.debug('discard')
         self._logger.debug(u'%s: %s', self.c, item)
         if item in self:
+            self._logger.debug('discarding the item')
             self.container._on_attr_changing(self.__change_field__, None)
             self._discard(item)
             setattr(item, self.__attr_counterpart__, None)
@@ -90,8 +105,10 @@ class ManyToManySet(InterlinkedSet):
     _logger = logging_util.get_logger_by_name(__name__, 'ManyToManySet')
 
     def add(self, item):
+        self._logger.debug('add')
         self._logger.debug(u'%s: %s', self.c, item)
         if item not in self:
+            self._logger.debug('adding the item')
             self.container._on_attr_changing(self.__change_field__, None)
             self._add(item)
             getattr(item, self.__attr_counterpart__).add(self.container)
@@ -99,8 +116,10 @@ class ManyToManySet(InterlinkedSet):
                                             Changeable.OP_ADD, item)
 
     def discard(self, item):
+        self._logger.debug('discard')
         self._logger.debug(u'%s: %s', self.c, item)
         if item in self:
+            self._logger.debug('discarding the item')
             self.container._on_attr_changing(self.__change_field__, None)
             self._discard(item)
             getattr(item, self.__attr_counterpart__).discard(self.container)

--- a/models/task.py
+++ b/models/task.py
@@ -540,43 +540,56 @@ class Task(Changeable, TaskBase):
 class InterlinkedChildren(OneToManySet):
     __change_field__ = Task.FIELD_CHILDREN
     __attr_counterpart__ = 'parent'
+    _logger = logging_util.get_logger_by_name(__name__, 'InterlinkedChildren')
 
 
 class InterlinkedTags(ManyToManySet):
     __change_field__ = Task.FIELD_TAGS
     __attr_counterpart__ = 'tasks'
+    _logger = logging_util.get_logger_by_name(__name__, 'InterlinkedTags')
 
 
 class InterlinkedUsers(ManyToManySet):
     __change_field__ = Task.FIELD_USERS
     __attr_counterpart__ = 'tasks'
+    _logger = logging_util.get_logger_by_name(__name__, 'InterlinkedUsers')
 
 
 class InterlinkedDependees(ManyToManySet):
     __change_field__ = Task.FIELD_DEPENDEES
     __attr_counterpart__ = 'dependants'
+    _logger = logging_util.get_logger_by_name(__name__, 'InterlinkedDependees')
 
 
 class InterlinkedDependants(ManyToManySet):
     __change_field__ = Task.FIELD_DEPENDANTS
     __attr_counterpart__ = 'dependees'
+    _logger = logging_util.get_logger_by_name(__name__,
+                                              'InterlinkedDependants')
 
 
 class InterlinkedPrioritizeBefore(ManyToManySet):
     __change_field__ = Task.FIELD_PRIORITIZE_BEFORE
     __attr_counterpart__ = 'prioritize_after'
-
+    _logger = logging_util.get_logger_by_name(__name__,
+                                              'InterlinkedPrioritizeBefore')
+∂
 
 class InterlinkedPrioritizeAfter(ManyToManySet):
     __change_field__ = Task.FIELD_PRIORITIZE_AFTER
     __attr_counterpart__ = 'prioritize_before'
+    _logger = logging_util.get_logger_by_name(__name__,
+                                              'InterlinkedPrioritizeAfter')
 
 
 class InterlinkedNotes(OneToManySet):
     __change_field__ = Task.FIELD_NOTES
     __attr_counterpart__ = 'task'
+    _logger = logging_util.get_logger_by_name(__name__, 'InterlinkedNotes')
 
 
 class InterlinkedAttachments(OneToManySet):
     __change_field__ = Task.FIELD_ATTACHMENTS
     __attr_counterpart__ = 'task'
+    _logger = logging_util.get_logger_by_name(__name__,
+                                              'InterlinkedAttachments')

--- a/models/task.py
+++ b/models/task.py
@@ -493,9 +493,11 @@ class Task(Changeable, TaskBase):
         return u'{:.2f}'.format(self.expected_cost)
 
     def is_user_authorized(self, user):
+        self._logger.debug(u'%s', self)
         return user in self.users
 
     def contains_dependency_cycle(self, visited=None):
+        self._logger.debug(u'%s', self)
         if visited is None:
             visited = set()
         if self in visited:
@@ -509,6 +511,7 @@ class Task(Changeable, TaskBase):
         return False
 
     def contains_priority_cycle(self, visited=None):
+        self._logger.debug(u'%s', self)
         if visited is None:
             visited = set()
         if self in visited:
@@ -521,6 +524,7 @@ class Task(Changeable, TaskBase):
         return False
 
     def clear_relationships(self):
+        self._logger.debug(u'%s', self)
         self.parent = None
         self.children.clear()
         self.tags.clear()

--- a/models/task.py
+++ b/models/task.py
@@ -573,7 +573,7 @@ class InterlinkedPrioritizeBefore(ManyToManySet):
     __attr_counterpart__ = 'prioritize_after'
     _logger = logging_util.get_logger_by_name(__name__,
                                               'InterlinkedPrioritizeBefore')
-∂
+
 
 class InterlinkedPrioritizeAfter(ManyToManySet):
     __change_field__ = Task.FIELD_PRIORITIZE_AFTER

--- a/models/user.py
+++ b/models/user.py
@@ -154,6 +154,7 @@ class User(Changeable, UserBase):
 
     @property
     def tasks(self):
+        self._logger.debug('%s', self)
         return self._tasks
 
     def clear_relationships(self):
@@ -163,6 +164,8 @@ class User(Changeable, UserBase):
 class InterlinkedTasks(ManyToManySet):
     __change_field__ = User.FIELD_TASKS
     __attr_counterpart__ = 'users'
+    _logger = logging_util.get_logger_by_name(__name__,
+                                              'InterlinkedTasks')
 
 
 class GuestUser(UserBase):

--- a/persistence_layer.py
+++ b/persistence_layer.py
@@ -398,9 +398,9 @@ class PersistenceLayer(object):
         self._logger.debug(u'begin, dbobj: %s', dbobj)
         if isinstance(dbobj, self.DbTask):
             import traceback
-            self._logger.debug(u'Got a DbTask. Current call stack is:')
-            for line in traceback.format_stack():
-                self._logger.debug('    ' + line)
+            call_stack = '    '.join(traceback.format_stack())
+            self._logger.debug(u'Got a DbTask. Current call stack is:\n    ' +
+                               call_stack)
         if dbobj is None:
             return None
         if not self._is_db_object(dbobj):

--- a/persistence_layer.py
+++ b/persistence_layer.py
@@ -24,38 +24,6 @@ def as_iterable(x):
     return (x,)
 
 
-class QueryWrapper(object):
-    def __init__(self, query, parent=None):
-        self.query = query
-        self.parent = parent
-
-    def all(self):
-        return self.query.all()
-
-    def get(self, *args, **kwargs):
-        return self.query.get(*args, **kwargs)
-
-    def filter(self, *args, **kwargs):
-        return QueryWrapper(self.query.filter(*args, **kwargs), parent=self)
-
-    def filter_by(self, *args, **kwargs):
-        return QueryWrapper(self.query.filter_by(*args, **kwargs), parent=self)
-
-    def __iter__(self, *args, **kwargs):
-        import logging
-        logging.getLogger(__name__).debug('QueryWrapper.__iter__: ',)
-        return self.query.__iter__(*args, **kwargs)
-
-    def outerjoin(self, *args, **kwargs):
-        return QueryWrapper(self.query.outerjoin(*args, **kwargs), parent=self)
-
-    def order_by(self, *args, **kwargs):
-        return QueryWrapper(self.query.order_by(*args, **kwargs), parent=self)
-
-    def limit(self, *args, **kwargs):
-        return QueryWrapper(self.query.limit(*args, **kwargs), parent=self)
-
-
 class Pager(object):
     page = None
     per_page = None
@@ -171,7 +139,6 @@ class PersistenceLayer(object):
                                           users_tasks_table,
                                           task_dependencies_table,
                                           task_prioritize_table)
-        self.db_task_query_wrapper = None
         self.DbNote = generate_note_class(db)
         self.DbAttachment = generate_attachment_class(db)
         self.DbUser = generate_user_class(db, users_tasks_table)
@@ -737,10 +704,7 @@ class PersistenceLayer(object):
 
     @property
     def task_query(self):
-        # return self.DbTask.query
-        if not self.db_task_query_wrapper:
-            self.db_task_query_wrapper = QueryWrapper(self.DbTask.query)
-        return self.db_task_query_wrapper
+        return self.DbTask.query
 
     def get_task(self, task_id):
         return self._get_domain_object_from_db_object(

--- a/persistence_layer.py
+++ b/persistence_layer.py
@@ -667,7 +667,7 @@ class PersistenceLayer(object):
 
     def _on_domain_object_attr_changed(self, domobj, field, operation, value):
         self._logger.debug(u'begin, domobj: %s, field: %s, op: %s, value: %s',
-                domobj, field, operation, value)
+                           domobj, field, operation, value)
 
         dbobj = self._get_db_object_from_domain_object(domobj)
         value2 = self._db_value_from_domain(field, value)

--- a/persistence_layer.py
+++ b/persistence_layer.py
@@ -387,6 +387,11 @@ class PersistenceLayer(object):
 
     def _get_domain_object_from_db_object(self, dbobj):
         self._logger.debug(u'begin, dbobj: %s', dbobj)
+        if isinstance(dbobj, self.DbTask):
+            import traceback
+            self._logger.debug(u'Got a DbTask. Current call stack is:')
+            for line in traceback.format_stack():
+                self._logger.debug('    ' + line)
         if dbobj is None:
             return None
         if not self._is_db_object(dbobj):

--- a/persistence_layer.py
+++ b/persistence_layer.py
@@ -398,9 +398,9 @@ class PersistenceLayer(object):
         self._logger.debug(u'begin, dbobj: %s', dbobj)
         if isinstance(dbobj, self.DbTask):
             import traceback
-            call_stack = '    '.join(traceback.format_stack())
-            self._logger.debug(u'Got a DbTask. Current call stack is:\n    ' +
-                               call_stack)
+            self._logger.debug(u'Got a DbTask. Current call stack is:')
+            for line in traceback.format_stack():
+                self._logger.debug('    ' + line)
         if dbobj is None:
             return None
         if not self._is_db_object(dbobj):

--- a/persistence_layer.py
+++ b/persistence_layer.py
@@ -24,6 +24,38 @@ def as_iterable(x):
     return (x,)
 
 
+class QueryWrapper(object):
+    def __init__(self, query, parent=None):
+        self.query = query
+        self.parent = parent
+
+    def all(self):
+        return self.query.all()
+
+    def get(self, *args, **kwargs):
+        return self.query.get(*args, **kwargs)
+
+    def filter(self, *args, **kwargs):
+        return QueryWrapper(self.query.filter(*args, **kwargs), parent=self)
+
+    def filter_by(self, *args, **kwargs):
+        return QueryWrapper(self.query.filter_by(*args, **kwargs), parent=self)
+
+    def __iter__(self, *args, **kwargs):
+        import logging
+        logging.getLogger(__name__).debug('QueryWrapper.__iter__: ',)
+        return self.query.__iter__(*args, **kwargs)
+
+    def outerjoin(self, *args, **kwargs):
+        return QueryWrapper(self.query.outerjoin(*args, **kwargs), parent=self)
+
+    def order_by(self, *args, **kwargs):
+        return QueryWrapper(self.query.order_by(*args, **kwargs), parent=self)
+
+    def limit(self, *args, **kwargs):
+        return QueryWrapper(self.query.limit(*args, **kwargs), parent=self)
+
+
 class Pager(object):
     page = None
     per_page = None
@@ -139,6 +171,7 @@ class PersistenceLayer(object):
                                           users_tasks_table,
                                           task_dependencies_table,
                                           task_prioritize_table)
+        self.db_task_query_wrapper = None
         self.DbNote = generate_note_class(db)
         self.DbAttachment = generate_attachment_class(db)
         self.DbUser = generate_user_class(db, users_tasks_table)
@@ -704,7 +737,10 @@ class PersistenceLayer(object):
 
     @property
     def task_query(self):
-        return self.DbTask.query
+        # return self.DbTask.query
+        if not self.db_task_query_wrapper:
+            self.db_task_query_wrapper = QueryWrapper(self.DbTask.query)
+        return self.db_task_query_wrapper
 
     def get_task(self, task_id):
         return self._get_domain_object_from_db_object(

--- a/persistence_layer.py
+++ b/persistence_layer.py
@@ -383,7 +383,7 @@ class PersistenceLayer(object):
         return self._domain_by_db[dbobj]
 
     def _create_domain_object_from_db_object(self, dbobj):
-        self._logger.debug(u'begin, dbobj: %2', dbobj)
+        self._logger.debug(u'begin, dbobj: %s', dbobj)
         if dbobj is None:
             raise ValueError('dbobj cannot be None')
         if not self._is_db_object(dbobj):

--- a/persistence_layer.py
+++ b/persistence_layer.py
@@ -387,11 +387,6 @@ class PersistenceLayer(object):
 
     def _get_domain_object_from_db_object(self, dbobj):
         self._logger.debug(u'begin, dbobj: %s', dbobj)
-        if isinstance(dbobj, self.DbTask):
-            import traceback
-            self._logger.debug(u'Got a DbTask. Current call stack is:')
-            for line in traceback.format_stack():
-                self._logger.debug('    ' + line)
         if dbobj is None:
             return None
         if not self._is_db_object(dbobj):

--- a/persistence_layer.py
+++ b/persistence_layer.py
@@ -55,15 +55,6 @@ class QueryWrapper(object):
     def limit(self, *args, **kwargs):
         return QueryWrapper(self.query.limit(*args, **kwargs), parent=self)
 
-    def paginate(self, *args, **kwargs):
-        return self.query.paginate(*args, **kwargs)
-
-    def __call__(self, *args, **kwargs):
-        return QueryWrapper(self.query(*args, **kwargs), parent=self)
-
-    def count(self, *args, **kwargs):
-        return self.query.count(*args, **kwargs)
-
 
 class Pager(object):
     page = None
@@ -765,7 +756,7 @@ class PersistenceLayer(object):
             return None
         return self.task_query.get(task_id)
 
-    def _get_tasks_query(self, entities=None, is_done=UNSPECIFIED, is_deleted=UNSPECIFIED,
+    def _get_tasks_query(self, is_done=UNSPECIFIED, is_deleted=UNSPECIFIED,
                          parent_id=UNSPECIFIED, parent_id_in=UNSPECIFIED,
                          users_contains=UNSPECIFIED, task_id_in=UNSPECIFIED,
                          task_id_not_in=UNSPECIFIED,
@@ -783,9 +774,6 @@ class PersistenceLayer(object):
            specified."""
 
         query = self.task_query
-
-        if entities:
-            query = query(entities)
 
         if is_done is not self.UNSPECIFIED:
             query = query.filter_by(is_done=is_done)

--- a/persistence_layer.py
+++ b/persistence_layer.py
@@ -55,6 +55,15 @@ class QueryWrapper(object):
     def limit(self, *args, **kwargs):
         return QueryWrapper(self.query.limit(*args, **kwargs), parent=self)
 
+    def paginate(self, *args, **kwargs):
+        return self.query.paginate(*args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        return QueryWrapper(self.query(*args, **kwargs), parent=self)
+
+    def count(self, *args, **kwargs):
+        return self.query.count(*args, **kwargs)
+
 
 class Pager(object):
     page = None
@@ -756,7 +765,7 @@ class PersistenceLayer(object):
             return None
         return self.task_query.get(task_id)
 
-    def _get_tasks_query(self, is_done=UNSPECIFIED, is_deleted=UNSPECIFIED,
+    def _get_tasks_query(self, entities=None, is_done=UNSPECIFIED, is_deleted=UNSPECIFIED,
                          parent_id=UNSPECIFIED, parent_id_in=UNSPECIFIED,
                          users_contains=UNSPECIFIED, task_id_in=UNSPECIFIED,
                          task_id_not_in=UNSPECIFIED,
@@ -774,6 +783,9 @@ class PersistenceLayer(object):
            specified."""
 
         query = self.task_query
+
+        if entities:
+            query = query(entities)
 
         if is_done is not self.UNSPECIFIED:
             query = query.filter_by(is_done=is_done)

--- a/tudor.py
+++ b/tudor.py
@@ -677,9 +677,11 @@ if __name__ == '__main__':
     elif args.hash_password is not None:
         print(app.bcrypt.generate_password_hash(args.hash_password))
     elif args.make_public is not None:
-        make_task_public(app.pl, args.make_public, descendants=args.descendants)
+        make_task_public(app.pl, args.make_public,
+                         descendants=args.descendants)
     elif args.make_private is not None:
-        make_task_private(app.pl, args.make_private, descendants=args.descendants)
+        make_task_private(app.pl, args.make_private,
+                          descendants=args.descendants)
     elif args.test_db_conn:
         test_db_conn(app.pl, args.debug)
     else:


### PR DESCRIPTION
Well, not _everything_. This PR adds logging statements for several methods. It is part of an investigation into a performance degradation. It would seem that creating a new task leads to the expansion of the current user's `tasks`collection, which is lazily populated. That then means that all of the user's other tasks get loaded from the db, even though they aren't needed for simply creating a new task. The logging statements where usefully in tracking down the problem.