### PR TITLE
File envvars

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,46 @@
+import sys
+import unittest
+from unittest.mock import patch
+
+from tudor import main
+
+
+class MainFunctionTests(unittest.TestCase):
+    def test_main(self):
+        with patch('tudor.print') as mock_print, \
+                patch('tudor.generate_app') as mock_generate:
+            app = mock_generate.return_value
+
+            # when
+            main([])
+
+            # then
+            mock_print.assert_any_call('__version__: 0.4', file=sys.stderr)
+            # mock_print.assert_any_call('__revision__: unknown', file=sys.stderr)
+            mock_print.assert_any_call('DEBUG: False', file=sys.stderr)
+            mock_print.assert_any_call('HOST: 127.0.0.1', file=sys.stderr)
+            mock_print.assert_any_call('PORT: 8304', file=sys.stderr)
+            mock_print.assert_any_call('DB_URI: sqlite:////tmp/test.db',
+                                       file=sys.stderr)
+            mock_print.assert_any_call('UPLOAD_FOLDER: /tmp/tudor/uploads',
+                                       file=sys.stderr)
+            mock_print.assert_any_call(
+                'ALLOWED_EXTENSIONS: txt,pdf,png,jpg,jpeg,gif',
+                file=sys.stderr)
+            assert mock_print.call_count == 8
+
+            # and
+            mock_generate.assert_called_once_with(
+                db_uri='sqlite:////tmp/test.db',
+                upload_folder='/tmp/tudor/uploads',
+                secret_key=None,
+                allowed_extensions='txt,pdf,png,jpg,jpeg,gif')
+
+            app.run.assert_called_once_with(debug=False, host="127.0.0.1",
+                port=8304)
+            # and
+            app.pl.create_all.assert_not_called()
+            app.bcrypt.generate_password_hash.assert_not_called()
+            app.ll.do_export_data.assert_not_called()
+            app.ll.do_import_data.assert_not_called()
+

--- a/tudor.py
+++ b/tudor.py
@@ -72,7 +72,10 @@ class Config(object):
             secret_key=environ.get('TUDOR_SECRET_KEY'))
 
 
-def get_config_from_command_line(args, defaults):
+def get_config_from_command_line(args, defaults=None):
+    if defaults is None:
+        defaults = Config.from_environ()
+
     parser = argparse.ArgumentParser()
     parser.add_argument('--debug', action='store_true',
                         default=defaults.DEBUG)
@@ -667,11 +670,7 @@ def create_user(pl, email, hashed_password, is_admin=False):
 
 if __name__ == '__main__':
 
-    default_config = Config()
-
-    env_config = Config.from_environ()
-
-    arg_config = get_config_from_command_line(sys.argv[1:], env_config)
+    arg_config = get_config_from_command_line(sys.argv[1:])
 
     print(f'__version__: {__version__}', file=sys.stderr)
     print(f'__revision__: {__revision__}', file=sys.stderr)

--- a/tudor.py
+++ b/tudor.py
@@ -105,6 +105,10 @@ class Config(object):
             args=ifn(first.args, second.args))
 
 
+class ConfigError(Exception):
+    pass
+
+
 def get_config_from_command_line(argv, defaults=None):
     if defaults is None:
         defaults = Config.from_environ()
@@ -168,15 +172,32 @@ def get_config_from_command_line(argv, defaults=None):
         try:
             with open(config.DB_URI_FILE) as f:
                 config.DB_URI = f.read()
-        except:
-            pass
+        except FileNotFoundError:
+            raise ConfigError(
+                f'Could not find uri file "{config.DB_URI_FILE}".')
+        except PermissionError:
+            raise ConfigError(
+                f'Permission error when opening uri file '
+                f'"{config.DB_URI_FILE}".')
+        except Exception as e:
+            raise ConfigError(
+                f'Error opening uri file "{config.DB_URI_FILE}": {e}')
 
     if config.SECRET_KEY is None and config.SECRET_KEY_FILE is not None:
         try:
             with open(config.SECRET_KEY_FILE) as f:
                 config.SECRET_KEY = f.read()
-        except (FileNotFoundError, PermissionError):
-            pass
+        except FileNotFoundError:
+            raise ConfigError(
+                f'Could not find secret key file "{config.SECRET_KEY_FILE}".')
+        except PermissionError:
+            raise ConfigError(
+                f'Permission error when opening secret key file '
+                f'"{config.SECRET_KEY_FILE}".')
+        except Exception as e:
+            raise ConfigError(
+                f'Error opening secret key file '
+                f'"{config.SECRET_KEY_FILE}": {e}')
 
     return config
 

--- a/tudor.py
+++ b/tudor.py
@@ -47,7 +47,9 @@ class Config(object):
                  db_uri_file=None,
                  upload_folder=DEFAULT_TUDOR_UPLOAD_FOLDER,
                  allowed_extensions=DEFAULT_TUDOR_ALLOWED_EXTENSIONS,
-                 secret_key=DEFAULT_TUDOR_SECRET_KEY, args=None):
+                 secret_key=DEFAULT_TUDOR_SECRET_KEY,
+                 secret_key_file=None,
+                 args=None):
         self.DEBUG = debug
         self.HOST = host
         self.PORT = port
@@ -56,6 +58,7 @@ class Config(object):
         self.UPLOAD_FOLDER = upload_folder
         self.ALLOWED_EXTENSIONS = allowed_extensions
         self.SECRET_KEY = secret_key
+        self.SECRET_KEY_FILE = secret_key_file
         self.args = args
 
     @staticmethod
@@ -72,7 +75,8 @@ class Config(object):
                                       DEFAULT_TUDOR_UPLOAD_FOLDER),
             allowed_extensions=environ.get('TUDOR_ALLOWED_EXTENSIONS',
                                            DEFAULT_TUDOR_ALLOWED_EXTENSIONS),
-            secret_key=environ.get('TUDOR_SECRET_KEY'))
+            secret_key=environ.get('TUDOR_SECRET_KEY'),
+            secret_key_file=environ.get('TUDOR_SECRET_KEY_FILE'))
 
     @classmethod
     def combine(cls, first, second):
@@ -96,6 +100,8 @@ class Config(object):
             allowed_extensions=ifn(first.ALLOWED_EXTENSIONS,
                                    second.ALLOWED_EXTENSIONS),
             secret_key=ifn(first.SECRET_KEY, second.SECRET_KEY),
+            secret_key_file=ifn(first.SECRET_KEY_FILE,
+                                second.SECRET_KEY_FILE),
             args=ifn(first.args, second.args))
 
 
@@ -113,6 +119,7 @@ def get_config_from_command_line(argv, defaults=None):
     parser.add_argument('--upload-folder', action='store')
     parser.add_argument('--allowed-extensions', action='store')
     parser.add_argument('--secret-key', action='store')
+    parser.add_argument('--secret-key-file', action='store')
     parser.add_argument('--create-secret-key', action='store_true')
     parser.add_argument('--hash-password', action='store')
     parser.add_argument('--make-public', metavar='TASK_ID', action='store',
@@ -151,6 +158,7 @@ def get_config_from_command_line(argv, defaults=None):
         db_uri_file=args.db_uri_file,
         upload_folder=args.upload_folder,
         secret_key=args.secret_key,
+        secret_key_file=args.secret_key_file,
         allowed_extensions=args.allowed_extensions,
         args=args)
 
@@ -161,6 +169,13 @@ def get_config_from_command_line(argv, defaults=None):
             with open(config.DB_URI_FILE) as f:
                 config.DB_URI = f.read()
         except:
+            pass
+
+    if config.SECRET_KEY is None and config.SECRET_KEY_FILE is not None:
+        try:
+            with open(config.SECRET_KEY_FILE) as f:
+                config.SECRET_KEY = f.read()
+        except (FileNotFoundError, PermissionError):
             pass
 
     return config

--- a/tudor.py
+++ b/tudor.py
@@ -739,9 +739,8 @@ def create_user(pl, email, hashed_password, is_admin=False):
     pl.commit()
 
 
-if __name__ == '__main__':
-
-    arg_config = get_config_from_command_line(sys.argv[1:])
+def main(argv):
+    arg_config = get_config_from_command_line(argv)
 
     print(f'__version__: {__version__}', file=sys.stderr)
     print(f'__revision__: {__revision__}', file=sys.stderr)
@@ -798,3 +797,7 @@ if __name__ == '__main__':
     else:
         app.run(debug=arg_config.DEBUG, host=arg_config.HOST,
                 port=arg_config.PORT)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])


### PR DESCRIPTION
This PR adds the ability to specify _files_ for the DB URI and secret key. Certain deployment scenarios rely on access controls provided by the operating system to protect sensitive information, making them a more secure alternative to bare environment variables. The PR adds two environment variables (`TUDOR_DB_URI_FILE` and `TUDOR_SECRET_KEY_FILE`) and two command-line flags (`--db-uri-file` and `--secret-key-file`) to specify paths to the URI and secret key. The bare config values still take precedence, so if the DU URI is given explicitly, the file envvar/cliarg will be ignored. If the bare value is _not_ given, the setup will try to find a file.