### PR TITLE
Fix option defaults

### DIFF
--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -209,17 +209,18 @@ class CommandLineTests(unittest.TestCase):
         self.assertEqual('asdf', user.hashed_password)
         self.assertFalse(user.is_admin)
 
+
 class ConfigTest(unittest.TestCase):
-    def test_init_no_args_yields_hard_coded_defaults(self):
+    def test_init_no_args_yields_none(self):
         # when
         result = Config()
         # then
-        self.assertIs(False, result.DEBUG)
-        self.assertEqual('127.0.0.1', result.HOST)
-        self.assertEqual(8304, result.PORT)
-        self.assertEqual('sqlite:////tmp/test.db', result.DB_URI)
-        self.assertEqual('/tmp/tudor/uploads', result.UPLOAD_FOLDER)
-        self.assertEqual('txt,pdf,png,jpg,jpeg,gif', result.ALLOWED_EXTENSIONS)
+        self.assertIsNone(result.DEBUG)
+        self.assertIsNone(result.HOST)
+        self.assertIsNone(result.PORT)
+        self.assertIsNone(result.DB_URI)
+        self.assertIsNone(result.UPLOAD_FOLDER)
+        self.assertIsNone(result.ALLOWED_EXTENSIONS)
         self.assertIsNone(result.SECRET_KEY)
         self.assertIsNone(result.args)
 
@@ -229,7 +230,7 @@ class ConfigTest(unittest.TestCase):
         # then
         self.assertIs(True, result.DEBUG)
 
-    def test_host_sets_(self):
+    def test_host_sets_host(self):
         # when
         result = Config(host='1.2.3.4')
         # then
@@ -307,16 +308,16 @@ class ConfigFromEnvironTest(unittest.TestCase):
         if 'TUDOR_SECRET_KEY' in os.environ:
             os.environ.pop('TUDOR_SECRET_KEY')
 
-    def test_from_environ_no_envvars_returns_defaults(self):
+    def test_from_environ_no_envvars_returns_none_or_false(self):
         # when
         result = Config.from_environ()
         # then
-        self.assertIs(False, result.DEBUG)
-        self.assertEqual('127.0.0.1', result.HOST)
-        self.assertEqual(8304, result.PORT)
-        self.assertEqual('sqlite:////tmp/test.db', result.DB_URI)
-        self.assertEqual('/tmp/tudor/uploads', result.UPLOAD_FOLDER)
-        self.assertEqual('txt,pdf,png,jpg,jpeg,gif', result.ALLOWED_EXTENSIONS)
+        self.assertIs(result.DEBUG, False)
+        self.assertIsNone(result.HOST)
+        self.assertIsNone(result.PORT)
+        self.assertIsNone(result.DB_URI)
+        self.assertIsNone(result.UPLOAD_FOLDER)
+        self.assertIsNone(result.ALLOWED_EXTENSIONS)
         self.assertIsNone(result.SECRET_KEY)
         self.assertIsNone(result.args)
 

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1,9 +1,11 @@
 import os
 import unittest
+from unittest.mock import patch, MagicMock
 
 from persistence.in_memory.layer import InMemoryPersistenceLayer
 from tudor import make_task_public, make_task_private, Config, \
-    get_config_from_command_line, create_user
+    get_config_from_command_line, create_user, get_db_uri, ConfigError, \
+    get_secret_key
 
 
 class CommandLineTests(unittest.TestCase):
@@ -514,3 +516,169 @@ class GetConfigFromCommandLineTest(unittest.TestCase):
         # then
         self.assertIsNotNone(result.args)
         self.assertTrue(result.args.test_db_conn)
+
+    @patch('tudor.open')
+    def test_get_db_uri_uri_returns_uri(self, _open):
+        # when
+        result = get_db_uri('asdf', 'zxcv')
+        # then
+        assert result == 'asdf'
+        # and
+        _open.assert_not_called()
+
+    @patch('tudor.open')
+    def test_get_db_uri_no_uri_returns_file(self, _open):
+        # given
+        _f = MagicMock()
+        _open.return_value = _f
+        _f.__enter__.return_value = _f
+        _f.read.return_value = 'qwer'
+        # when
+        result = get_db_uri(None, 'zxcv')
+        # then
+        assert result == 'qwer'
+        # and
+        _open.assert_called_once_with('zxcv')
+        _f.read.assert_called_once_with()
+
+    @patch('tudor.open')
+    def test_get_db_uri_neither_uri_nor_file_returns_none(self, _open):
+        # when
+        result = get_db_uri(None, None)
+        # then
+        assert result is None
+        # and
+        _open.assert_not_called()
+
+    @patch('tudor.open')
+    def test_get_db_uri_no_file_returns_uri(self, _open):
+        # when
+        result = get_db_uri('asdf', None)
+        # then
+        assert result == 'asdf'
+        # and
+        _open.assert_not_called()
+
+    @patch('tudor.open')
+    def test_get_db_uri_raises_when_open_raises_fnf(self, _open):
+        # given
+        _f = MagicMock()
+        _open.return_value = _f
+        _f.__enter__.return_value = _f
+        _f.read.side_effect = FileNotFoundError
+        # expect
+        with self.assertRaises(ConfigError) as exc:
+            get_db_uri(None, 'zxcv')
+        # and
+        assert str(exc.exception) == 'Could not find uri file "zxcv".'
+
+    @patch('tudor.open')
+    def test_get_db_uri_raises_when_open_raises_perms(self, _open):
+        # given
+        _f = MagicMock()
+        _open.return_value = _f
+        _f.__enter__.return_value = _f
+        _f.read.side_effect = PermissionError
+        # expect
+        with self.assertRaises(ConfigError) as exc:
+            get_db_uri(None, 'zxcv')
+        # and
+        assert str(exc.exception) == \
+               'Permission error when opening uri file "zxcv".'
+
+    @patch('tudor.open')
+    def test_get_db_uri_raises_when_open_raises_other(self, _open):
+        # given
+        _f = MagicMock()
+        _open.return_value = _f
+        _f.__enter__.return_value = _f
+        _f.read.side_effect = Exception('something')
+        # expect
+        with self.assertRaises(ConfigError) as exc:
+            get_db_uri(None, 'zxcv')
+        # and
+        assert str(exc.exception) == \
+               'Error opening uri file "zxcv": something'
+
+    @patch('tudor.open')
+    def test_get_secret_key_uri_returns_uri(self, _open):
+        # when
+        result = get_secret_key('asdf', 'zxcv')
+        # then
+        assert result == 'asdf'
+        # and
+        _open.assert_not_called()
+
+    @patch('tudor.open')
+    def test_get_secret_key_no_uri_returns_file(self, _open):
+        # given
+        _f = MagicMock()
+        _open.return_value = _f
+        _f.__enter__.return_value = _f
+        _f.read.return_value = 'qwer'
+        # when
+        result = get_secret_key(None, 'zxcv')
+        # then
+        assert result == 'qwer'
+        # and
+        _open.assert_called_once_with('zxcv')
+        _f.read.assert_called_once_with()
+
+    @patch('tudor.open')
+    def test_get_secret_key_neither_uri_nor_file_returns_none(self, _open):
+        # when
+        result = get_secret_key(None, None)
+        # then
+        assert result is None
+        # and
+        _open.assert_not_called()
+
+    @patch('tudor.open')
+    def test_get_secret_key_no_file_returns_uri(self, _open):
+        # when
+        result = get_secret_key('asdf', None)
+        # then
+        assert result == 'asdf'
+        # and
+        _open.assert_not_called()
+
+    @patch('tudor.open')
+    def test_get_secret_key_raises_when_open_raises_fnf(self, _open):
+        # given
+        _f = MagicMock()
+        _open.return_value = _f
+        _f.__enter__.return_value = _f
+        _f.read.side_effect = FileNotFoundError
+        # expect
+        with self.assertRaises(ConfigError) as exc:
+            get_secret_key(None, 'zxcv')
+        # and
+        assert str(exc.exception) == 'Could not find secret key file "zxcv".'
+
+    @patch('tudor.open')
+    def test_get_secret_key_raises_when_open_raises_perms(self, _open):
+        # given
+        _f = MagicMock()
+        _open.return_value = _f
+        _f.__enter__.return_value = _f
+        _f.read.side_effect = PermissionError
+        # expect
+        with self.assertRaises(ConfigError) as exc:
+            get_secret_key(None, 'zxcv')
+        # and
+        assert str(exc.exception) == \
+               'Permission error when opening secret key file "zxcv".'
+
+    @patch('tudor.open')
+    def test_get_secret_key_raises_when_open_raises_other(self, _open):
+        # given
+        _f = MagicMock()
+        _open.return_value = _f
+        _f.__enter__.return_value = _f
+        _f.read.side_effect = Exception('something')
+        # expect
+        with self.assertRaises(ConfigError) as exc:
+            get_secret_key(None, 'zxcv')
+        # and
+        assert str(exc.exception) == \
+               'Error opening secret key file "zxcv": something'

--- a/tudor.py
+++ b/tudor.py
@@ -700,41 +700,50 @@ def create_user(pl, email, hashed_password, is_admin=False):
     pl.commit()
 
 
-def main(argv):
-    arg_config = get_config_from_command_line(argv)
-
-    if arg_config.DB_URI is None and arg_config.DB_URI_FILE is not None:
+def get_db_uri(db_uri, db_uri_file):
+    if db_uri is None and db_uri_file is not None:
         try:
-            with open(arg_config.DB_URI_FILE) as f:
-                arg_config.DB_URI = f.read()
+            with open(db_uri_file) as f:
+                return f.read()
         except FileNotFoundError:
             raise ConfigError(
-                f'Could not find uri file "{arg_config.DB_URI_FILE}".')
+                f'Could not find uri file "{db_uri_file}".')
         except PermissionError:
             raise ConfigError(
                 f'Permission error when opening uri file '
-                f'"{arg_config.DB_URI_FILE}".')
+                f'"{db_uri_file}".')
         except Exception as e:
             raise ConfigError(
-                f'Error opening uri file "{arg_config.DB_URI_FILE}": {e}')
+                f'Error opening uri file "{db_uri_file}": {e}')
+    return db_uri
 
-    if arg_config.SECRET_KEY is None and \
-            arg_config.SECRET_KEY_FILE is not None:
+
+def get_secret_key(secret_key, secret_key_file):
+    if secret_key is None and secret_key_file is not None:
         try:
-            with open(arg_config.SECRET_KEY_FILE) as f:
-                arg_config.SECRET_KEY = f.read()
+            with open(secret_key_file) as f:
+                return f.read()
         except FileNotFoundError:
             raise ConfigError(
                 f'Could not find secret key file '
-                f'"{arg_config.SECRET_KEY_FILE}".')
+                f'"{secret_key_file}".')
         except PermissionError:
             raise ConfigError(
                 f'Permission error when opening secret key file '
-                f'"{arg_config.SECRET_KEY_FILE}".')
+                f'"{secret_key_file}".')
         except Exception as e:
             raise ConfigError(
                 f'Error opening secret key file '
-                f'"{arg_config.SECRET_KEY_FILE}": {e}')
+                f'"{secret_key_file}": {e}')
+    return secret_key
+
+
+def main(argv):
+    arg_config = get_config_from_command_line(argv)
+
+    arg_config.DB_URI = get_db_uri(arg_config.DB_URI, arg_config.DB_URI_FILE)
+    arg_config.SECRET_KEY = get_secret_key(arg_config.SECRET_KEY,
+                                           arg_config.SECRET_KEY_FILE)
 
     if arg_config.DEBUG is None:
         arg_config.DEBUG = DEFAULT_TUDOR_DEBUG

--- a/tudor.py
+++ b/tudor.py
@@ -42,14 +42,10 @@ DEFAULT_TUDOR_SECRET_KEY = None
 
 
 class Config(object):
-    def __init__(self, debug=DEFAULT_TUDOR_DEBUG, host=DEFAULT_TUDOR_HOST,
-                 port=DEFAULT_TUDOR_PORT, db_uri=DEFAULT_TUDOR_DB_URI,
-                 db_uri_file=None,
-                 upload_folder=DEFAULT_TUDOR_UPLOAD_FOLDER,
-                 allowed_extensions=DEFAULT_TUDOR_ALLOWED_EXTENSIONS,
-                 secret_key=DEFAULT_TUDOR_SECRET_KEY,
-                 secret_key_file=None,
-                 args=None):
+    def __init__(self, debug=None, host=None, port=None, db_uri=None,
+                 db_uri_file=None, upload_folder=None,
+                 allowed_extensions=None, secret_key=None,
+                 secret_key_file=None, args=None):
         self.DEBUG = debug
         self.HOST = host
         self.PORT = port
@@ -64,17 +60,13 @@ class Config(object):
     @staticmethod
     def from_environ():
         return Config(
-            debug=bool_from_str(
-                environ.get('TUDOR_DEBUG', DEFAULT_TUDOR_DEBUG)),
-            host=environ.get('TUDOR_HOST', DEFAULT_TUDOR_HOST),
-            port=int_from_str(environ.get('TUDOR_PORT', DEFAULT_TUDOR_PORT),
-                              DEFAULT_TUDOR_PORT),
-            db_uri=environ.get('TUDOR_DB_URI', DEFAULT_TUDOR_DB_URI),
+            debug=bool_from_str(environ.get('TUDOR_DEBUG')),
+            host=environ.get('TUDOR_HOST'),
+            port=int_from_str(environ.get('TUDOR_PORT')),
+            db_uri=environ.get('TUDOR_DB_URI'),
             db_uri_file=environ.get('TUDOR_DB_URI_FILE'),
-            upload_folder=environ.get('TUDOR_UPLOAD_FOLDER',
-                                      DEFAULT_TUDOR_UPLOAD_FOLDER),
-            allowed_extensions=environ.get('TUDOR_ALLOWED_EXTENSIONS',
-                                           DEFAULT_TUDOR_ALLOWED_EXTENSIONS),
+            upload_folder=environ.get('TUDOR_UPLOAD_FOLDER'),
+            allowed_extensions=environ.get('TUDOR_ALLOWED_EXTENSIONS'),
             secret_key=environ.get('TUDOR_SECRET_KEY'),
             secret_key_file=environ.get('TUDOR_SECRET_KEY_FILE'))
 
@@ -167,37 +159,6 @@ def get_config_from_command_line(argv, defaults=None):
         args=args)
 
     config = Config.combine(arg_config, defaults)
-
-    if config.DB_URI is None and config.DB_URI_FILE is not None:
-        try:
-            with open(config.DB_URI_FILE) as f:
-                config.DB_URI = f.read()
-        except FileNotFoundError:
-            raise ConfigError(
-                f'Could not find uri file "{config.DB_URI_FILE}".')
-        except PermissionError:
-            raise ConfigError(
-                f'Permission error when opening uri file '
-                f'"{config.DB_URI_FILE}".')
-        except Exception as e:
-            raise ConfigError(
-                f'Error opening uri file "{config.DB_URI_FILE}": {e}')
-
-    if config.SECRET_KEY is None and config.SECRET_KEY_FILE is not None:
-        try:
-            with open(config.SECRET_KEY_FILE) as f:
-                config.SECRET_KEY = f.read()
-        except FileNotFoundError:
-            raise ConfigError(
-                f'Could not find secret key file "{config.SECRET_KEY_FILE}".')
-        except PermissionError:
-            raise ConfigError(
-                f'Permission error when opening secret key file '
-                f'"{config.SECRET_KEY_FILE}".')
-        except Exception as e:
-            raise ConfigError(
-                f'Error opening secret key file '
-                f'"{config.SECRET_KEY_FILE}": {e}')
 
     return config
 
@@ -741,6 +702,54 @@ def create_user(pl, email, hashed_password, is_admin=False):
 
 def main(argv):
     arg_config = get_config_from_command_line(argv)
+
+    if arg_config.DB_URI is None and arg_config.DB_URI_FILE is not None:
+        try:
+            with open(arg_config.DB_URI_FILE) as f:
+                arg_config.DB_URI = f.read()
+        except FileNotFoundError:
+            raise ConfigError(
+                f'Could not find uri file "{arg_config.DB_URI_FILE}".')
+        except PermissionError:
+            raise ConfigError(
+                f'Permission error when opening uri file '
+                f'"{arg_config.DB_URI_FILE}".')
+        except Exception as e:
+            raise ConfigError(
+                f'Error opening uri file "{arg_config.DB_URI_FILE}": {e}')
+
+    if arg_config.SECRET_KEY is None and \
+            arg_config.SECRET_KEY_FILE is not None:
+        try:
+            with open(arg_config.SECRET_KEY_FILE) as f:
+                arg_config.SECRET_KEY = f.read()
+        except FileNotFoundError:
+            raise ConfigError(
+                f'Could not find secret key file '
+                f'"{arg_config.SECRET_KEY_FILE}".')
+        except PermissionError:
+            raise ConfigError(
+                f'Permission error when opening secret key file '
+                f'"{arg_config.SECRET_KEY_FILE}".')
+        except Exception as e:
+            raise ConfigError(
+                f'Error opening secret key file '
+                f'"{arg_config.SECRET_KEY_FILE}": {e}')
+
+    if arg_config.DEBUG is None:
+        arg_config.DEBUG = DEFAULT_TUDOR_DEBUG
+    if arg_config.HOST is None:
+        arg_config.HOST = DEFAULT_TUDOR_HOST
+    if arg_config.PORT is None:
+        arg_config.PORT = DEFAULT_TUDOR_PORT
+    if arg_config.DB_URI is None:
+        arg_config.DB_URI = DEFAULT_TUDOR_DB_URI
+    if arg_config.UPLOAD_FOLDER is None:
+        arg_config.UPLOAD_FOLDER = DEFAULT_TUDOR_UPLOAD_FOLDER
+    if arg_config.ALLOWED_EXTENSIONS is None:
+        arg_config.ALLOWED_EXTENSIONS = DEFAULT_TUDOR_ALLOWED_EXTENSIONS
+    if arg_config.SECRET_KEY is None:
+        arg_config.SECRET_KEY = DEFAULT_TUDOR_SECRET_KEY
 
     print(f'__version__: {__version__}', file=sys.stderr)
     print(f'__revision__: {__revision__}', file=sys.stderr)


### PR DESCRIPTION
This PR fixes some oversites from #79 . The problem comes when trying to use the DB-uri-file option. It was never being triggered because the DB_URI option was always non-null because of the `DEFAULT_TUDOR_DB_URI` being non-null.