### PR TITLE
2191 re-arrange view task page

### DIFF
--- a/static/tudor.css
+++ b/static/tudor.css
@@ -28,6 +28,9 @@ thead {
     border: 1px solid #e9e9e9;
 }
 
+.task_notes {
+    width: 100%;
+}
 .task_notes td {
     border: 1px solid #e9e9e9;
 }

--- a/static/tudor.css
+++ b/static/tudor.css
@@ -16,6 +16,10 @@ thead {
     background-color: #d0d0d0;
 }
 
+.task_table_summary {
+    /*padding-left: { {depth*1.5} }em*/
+}
+
 .tasks .odd, .task_children .odd, tr.odd {
     background-color: #f0f0f0;
 }

--- a/static/tudor.css
+++ b/static/tudor.css
@@ -1,10 +1,10 @@
 
-.task_description
-{
-    border-color: #000000;
-    padding: 10px; /* csslint allow: box-model */
-    width: 870px; /* csslint allow: box-model */
-}
+/*.task_description*/
+/*{*/
+/*    border-color: #000000;*/
+/*    padding: 10px; !* csslint allow: box-model *!*/
+/*    width: 870px; !* csslint allow: box-model *!*/
+/*}*/
 
 table {
     border-collapse: collapse;

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -392,13 +392,8 @@
     <p></p>
     <a class="btn btn-danger btn-xs" href="{{ url_for('convert_task_to_tag', id=task.id) }}">Convert to tag</a>
     {% endif %}
-</div>
-<div class="task_body_panel">
-    <div class="task_description">{{ task.description|gfm if task.description != None }}</div>
-</div>
-</div>
-</div>
-<div>
+
+
     <h4>Child Tasks</h4>
     {% if show_hierarchy %}
         {{ render_task_table(descendants, task, cycle,
@@ -426,6 +421,11 @@
     <p><a class="btn btn-default" href="{{ url_for('new_task', parent_id=task.id) }}"><span class="glyphicon glyphicon-plus"></span> New Child Task</a></p>
     {% endif %}
 
+</div>
+<div class="task_body_panel">
+    <div class="task_description">{{ task.description|gfm if task.description != None }}</div>
+</div>
+</div>
 </div>
 <div>
     <p>

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -114,7 +114,8 @@
         {{  breadcrumb_parent(task) }}
         <li class="active">{{ task.summary }}</li>
     </ol>
-    <p></p>
+    <h1 class="info_panel_value {{ task.get_css_class()|safe }}">{{ task.summary|d }}</h1>
+    <p><br/></p>
 
 <div class="panel_container">
 <div class="info_panel">

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -72,6 +72,81 @@
 .note_panel {
     padding: 10px;
 }
+
+.attachment_list {
+    padding-left: 0;
+    margin-bottom: 20px;
+    box-sizing: border-box;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.42857143;
+    color: #333;
+}
+
+.attachment_list_item {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.42857143;
+    box-sizing: border-box;
+    text-decoration: none;
+    position: relative;
+    display: block;
+    padding: 10px 15px;
+    margin-bottom: -1px;
+    background-color: #fff;
+    border: 1px solid #ddd;
+    color: #555;
+}
+
+.attachment_list_item:focus,
+.attachment_list_item:hover {
+    color: #555;
+    text-decoration: none;
+    background-color: #f5f5f5;
+}
+
+a.attachment_list_item {
+    text-decoration: none;
+}
+
+.attachment_list_item:first-child {
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+}
+
+.attachment_list_item:last-child {
+    margin-bottom: 0;
+    border-bottom-right-radius: 4px;
+    border-bottom-left-radius: 4px;
+}
+
+.attachment_header {
+    font-size: 14px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    font-family: inherit;
+    font-weight: 500;
+    line-height: 1.1;
+    color: inherit;
+    box-sizing: border-box;
+}
+
+.attachment_timestamp {
+    font-size: 12px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    font-family: inherit;
+    font-weight: 500;
+    line-height: 1.1;
+    color: inherit;
+    box-sizing: border-box;
+}
+
+.attachment_description {
+    margin: 0 0 10px;
+    box-sizing: border-box;
+}
+
 </style>
 
 {% endblock %}
@@ -105,15 +180,15 @@
     <div class="attachment_section">
     {%  if task.attachments %}
         <h4>Attachments</h4>
-        <div class="list-group">
+        <div class="attachment_list">
             {% for att in task.attachments %}
-            <a class="list-group-item" href="{{ url_for('get_attachment', aid=att.id, x=att.filename) }}">
-                <h5><span class="glyphicon glyphicon-file"></span>&nbsp;{{ att.filename if att.filename != None }} ({{ att.id }})</h5>
-                <h6>{{ att.timestamp }}</h6>
-                <p>{{ att.description }}</p>
+            <a class="attachment_list_item" href="{{ url_for('get_attachment', aid=att.id, x=att.filename) }}">
+                <div class="attachment_header "><span class="glyphicon glyphicon-file"></span>&nbsp;{{ att.filename if att.filename != None }} ({{ att.id }})</div>
+                <div class="attachment_timestamp ">{{ att.timestamp }}</div>
+                <div class="attachment_description ">{{ att.description }}</div>
             </a>
             {% endfor %}
-            <div class="list-group-item">
+            <div class="attachment_list_item">
                 <form action="{{ url_for('new_attachment') }}" method="post" enctype="multipart/form-data">
                     <input type="hidden" name="task_id" value="{{ task.id }}">
                     <p style="margin-top: 15px"><input type="file" name="filename" /></p>

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -33,6 +33,7 @@
 
 .info_panel {
     width: calc(12px + min(450px, 30%));
+    background-color: #1c9c1a;
 }
 
 .info_panel_row {
@@ -97,6 +98,9 @@
     display: block;
 }
 
+.note_panel {
+    background-color: #1a1c9c;
+}
 </style>
 
 {% endblock %}
@@ -444,7 +448,7 @@
     </p>
     <p><a class="btn btn-default" href="{{ url_for('view_task_hierarchy', id=task.id) }}">hierarchy view</a></p>
 </div>
-<div>
+<div class="note_panel">
     <h4>Notes</h4>
     <table class="task_notes">
         <thead>

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -95,13 +95,14 @@
 {% block content %}
 <div class="container">
 <div>
-    {% set can_edit = ops.user_can_edit_task(task, current_user) %}
-    {% if can_edit %}
-    <a class="btn btn-primary" href="{{ url_for('edit_task', id=task.id) }}">Edit</a>
-    {% endif %}
-    <p></p>
 <div class="panel_container">
 <div class="info_panel">
+
+        {% set can_edit = ops.user_can_edit_task(task, current_user) %}
+        {% if can_edit %}
+        <a class="btn btn-primary" href="{{ url_for('edit_task', id=task.id) }}">Edit</a>
+        {% endif %}
+        <p></p>
 
         <div class="info_panel_row">
             <div class="info_panel_label"><h2>ID</h2></div>

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -363,6 +363,29 @@
                 </ul>
             </div>
         </div>
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>Attachments</h2></div>
+            <div class="list-group">
+                {% for att in task.attachments %}
+                <a class="list-group-item" href="{{ url_for('get_attachment', aid=att.id, x=att.filename) }}">
+                    <h5><span class="glyphicon glyphicon-file"></span>&nbsp;{{ att.filename if att.filename != None }} ({{ att.id }})</h5>
+                    <h6>{{ att.timestamp }}</h6>
+                    <p>{{ att.description }}</p>
+                </a>
+                {% endfor %}
+                <div class="list-group-item">
+                    <form action="{{ url_for('new_attachment') }}" method="post" enctype="multipart/form-data">
+                        <input type="hidden" name="task_id" value="{{ task.id }}">
+                        <p style="margin-top: 15px"><input type="file" name="filename" /></p>
+                        <p>
+                            <input type="text" name="description" maxlength="100" />
+                            <input type="submit" value="Attach" />
+                        </p>
+                    </form>
+                </div>
+            </div>
+
+        </div>
     <p></p>
     {% if can_edit %}
     <a class="btn btn-primary" href="{{ url_for('edit_task', id=task.id) }}">Edit</a>
@@ -454,42 +477,6 @@
     </table>
 
 </div>
-<div>
-    <h4>Attachments</h4>
-    <table class="task_attachments">
-        <thead>
-        <tr>
-            <th>ID</th>
-            <th>Timestamp</th>
-            <th>Filename</th>
-            <th>Description</th>
-        </tr>
-        </thead>
-        {% for att in task.attachments %}
-        <tr>
-            <td>{{ att.id }}</td>
-            <td>{{ att.timestamp }}</td>
-            <td><a href="{{ url_for('get_attachment', aid=att.id, x=att.filename) }}">{{ att.filename if att.filename != None }}</a></td>
-            <td>{{ att.description }}</td>
-        </tr>
-        {% endfor %}
-        {% if can_edit %}
-        <tr>
-            <td></td>
-            <td></td>
-            <form action="{{ url_for('new_attachment') }}" method="post" enctype="multipart/form-data">
-                <input type="hidden" name="task_id" value="{{ task.id }}">
-                <td>
-                    <input type="file" name="filename" />
-                </td>
-                <td>
-                    <input type="text" name="description" maxlength="100" />
-                    <input type="submit" value="Attach" />
-                </td>
-            </form>
-        </tr>
-        {% endif %}
-    </table>
-</div>
+
 </div>
 {% endblock %}

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -95,6 +95,19 @@
 {% block content %}
 <div class="container">
 <div>
+
+    <ol class="breadcrumb">
+    {% macro breadcrumb_parent(t) -%}
+        {% if t.parent != None %}
+            {{  breadcrumb_parent(t.parent) }}
+            <li><a class="" href="{{ url_for('view_task', id=t.parent.id) }}">{{ t.parent.summary }}</a></li>
+        {% endif %}
+    {%- endmacro %}
+        {{  breadcrumb_parent(task) }}
+        <li class="active">{{ task.summary }}</li>
+    </ol>
+    <p></p>
+
 <div class="panel_container">
 <div class="info_panel">
 

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -93,6 +93,9 @@
 .child_task_section {
 }
 
+.attachment_section {
+}
+
 .note_panel {
     padding: 10px;
 }
@@ -121,6 +124,31 @@
 
 <div class="task_body_panel col-md-8">
     <div class="task_description">{{ task.description|gfm if task.description != None }}</div>
+
+    <div class="attachment_section">
+    {%  if task.attachments %}
+        <h4>Attachments</h4>
+        <div class="list-group">
+            {% for att in task.attachments %}
+            <a class="list-group-item" href="{{ url_for('get_attachment', aid=att.id, x=att.filename) }}">
+                <h5><span class="glyphicon glyphicon-file"></span>&nbsp;{{ att.filename if att.filename != None }} ({{ att.id }})</h5>
+                <h6>{{ att.timestamp }}</h6>
+                <p>{{ att.description }}</p>
+            </a>
+            {% endfor %}
+            <div class="list-group-item">
+                <form action="{{ url_for('new_attachment') }}" method="post" enctype="multipart/form-data">
+                    <input type="hidden" name="task_id" value="{{ task.id }}">
+                    <p style="margin-top: 15px"><input type="file" name="filename" /></p>
+                    <p>
+                        <input type="text" name="description" maxlength="100" />
+                        <input type="submit" value="Attach" />
+                    </p>
+                </form>
+            </div>
+        </div>
+    {%  endif %}
+    </div>
 
     <div class="child_task_section">
     <hr/>
@@ -400,29 +428,6 @@
                 {% endif %}
                 </ul>
             </div>
-        </div>
-        <div class="info_panel_row">
-            <div class="info_panel_label"><h2>Attachments</h2></div>
-            <div class="list-group">
-                {% for att in task.attachments %}
-                <a class="list-group-item" href="{{ url_for('get_attachment', aid=att.id, x=att.filename) }}">
-                    <h5><span class="glyphicon glyphicon-file"></span>&nbsp;{{ att.filename if att.filename != None }} ({{ att.id }})</h5>
-                    <h6>{{ att.timestamp }}</h6>
-                    <p>{{ att.description }}</p>
-                </a>
-                {% endfor %}
-                <div class="list-group-item">
-                    <form action="{{ url_for('new_attachment') }}" method="post" enctype="multipart/form-data">
-                        <input type="hidden" name="task_id" value="{{ task.id }}">
-                        <p style="margin-top: 15px"><input type="file" name="filename" /></p>
-                        <p>
-                            <input type="text" name="description" maxlength="100" />
-                            <input type="submit" value="Attach" />
-                        </p>
-                    </form>
-                </div>
-            </div>
-
         </div>
     <p></p>
     {% if can_edit %}

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -125,6 +125,10 @@
 <div class="task_body_panel col-md-8">
     <div class="task_description">{{ task.description|gfm if task.description != None }}</div>
 
+    {% if can_edit %}
+    <a class="btn btn-primary" href="{{ url_for('edit_task', id=task.id) }}">Edit</a>
+    {% endif %}
+
     <div class="attachment_section">
     {%  if task.attachments %}
         <h4>Attachments</h4>

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -10,7 +10,7 @@
 {
     border-color: #000000;
     padding: 10px; /* csslint allow: box-model */
-    width: 870px; /* csslint allow: box-model */
+    {#width: 870px; /* csslint allow: box-model */#}
     background-color: #9C1A1C;
 }
 
@@ -18,6 +18,75 @@
     max-width: 1em;
     background-color: #86989B;
     {#display: block;#}
+}
+
+.panel_container {
+    flex-wrap: nowrap;
+    height: 100%;
+    -moz-box-align: initial;
+    align-items: initial;
+
+    display: flex;
+    max-width: 100%;
+    position: relative;
+}
+
+.info_panel {
+    width: calc(12px + min(450px, 30%));
+}
+
+.info_panel_row {
+    display: flex;
+    flex-wrap: wrap;
+    {#margin-bottom: 16px;#}
+    word-break: break-word;
+
+    {#background-color: #11557C;#}
+
+}
+
+.info_panel_label {
+
+    position: relative;
+    -moz-box-flex: 1;
+    flex-grow: 1;
+    box-sizing: border-box;
+    padding-right: 24px;
+    min-width: 90px;
+    width: 33.33%;
+    padding-top: 8px;
+    max-width: 120px;
+    line-height: 1;
+
+    {#background-color: #3A7734;#}
+}
+
+.info_panel_label h2 {
+
+    box-sizing: border-box;
+    font-size: 0.857143em;
+    font-style: inherit;
+    line-height: 1.33333;
+    font-weight: 600;
+    margin-top: 0;
+    margin-bottom: 0;
+
+    {#background-color: #888833;#}
+}
+
+.info_panel_value {
+    {#background-color: #86989B;#}
+
+    -moz-box-flex: 1;
+    flex-grow: 1;
+    width: 66.67%;
+    box-sizing: border-box;
+    margin-top: 2px;
+    margin-bottom: 2px;
+}
+
+.task_body_panel {
+    width: calc(-12px + min(798px, 70%))
 }
 
 </style>
@@ -31,15 +100,24 @@
     <a class="btn btn-primary" href="{{ url_for('edit_task', id=task.id) }}">Edit</a>
     {% endif %}
     <p></p>
-<table>
-<tr><td style="vertical-align: top;">
-    <table class="task_info">
-        <tr><td>ID</td><td>{{ task.id }}</td></tr>
-        <tr><td>Summary</td><td{{ task.get_css_class_attr()|safe }}>{{ task.summary|d }}</td></tr>
-        <tr><td>Deadline</td><td>{{ task.deadline|d }}</td></tr>
-        <tr>
-            <td>Done?</td>
-            <td>{{ task.is_done }}
+<div class="panel_container">
+<div class="info_panel">
+
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>ID</h2></div>
+            <div class="info_panel_value">{{ task.id }}</div>
+        </div>
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>Summary</h2></div>
+            <div class="info_panel_value {{ task.get_css_class()|safe }}">{{ task.summary|d }}</div>
+        </div>
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>Deadline</h2></div>
+            <div class="info_panel_value">{{ task.deadline|d }}</div>
+        </div>
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>Done?</h2></div>
+            <div class="info_panel_value">{{ task.is_done }}
                 {% if can_edit %}
                 <small>
                     {% if task.is_done %}
@@ -49,11 +127,11 @@
                     {% endif %}
                 </small>
                 {% endif %}
-            </td>
-        </tr>
-        <tr>
-            <td>Deleted?</td>
-            <td>{{ task.is_deleted }}
+            </div>
+        </div>
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>Deleted?</h2></div>
+            <div class="info_panel_value">{{ task.is_deleted }}
                 {% if can_edit %}
                 <small>
                     {% if task.is_deleted %}
@@ -63,24 +141,33 @@
                     {% endif %}
                 </small>
                 {% endif %}
-            </td>
-        </tr>
-        <tr><td>Order #</td><td>{{ task.order_num if task.order_num != None }}</td></tr>
-        <tr><td>Expected duration</td><td>{{ task.get_expected_duration_for_viewing() }}</td></tr>
-        <tr><td>Expected cost</td><td>${{ task.get_expected_cost_for_viewing() }}</td></tr>
-        <tr>
-            <td>Parent Task</td>
-            <td>
+            </div>
+        </div>
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>Order #</h2></div>
+            <div class="info_panel_value">{{ task.order_num if task.order_num != None }}</div>
+        </div>
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>Expected duration</h2></div>
+            <div class="info_panel_value">{{ task.get_expected_duration_for_viewing() }}</div>
+        </div>
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>Expected cost</h2></div>
+            <div class="info_panel_value">${{ task.get_expected_cost_for_viewing() }}</div>
+        </div>
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>Parent Task</h2></div>
+            <div class="info_panel_value">
                 {% if task.parent_id != None %}
                 <a href="{{ url_for('view_task', id=task.parent_id) }}" {{ task.parent.get_css_class_attr()|safe }}>{{ task.parent.summary if task.parent != None }} ({{ task.parent_id if task.parent_id != None }})</a>
                 {% else %}
                 None
                 {% endif %}
-            </td>
-        </tr>
-        <tr>
-            <td>Public?</td>
-            <td>{{ task.is_public }}
+            </div>
+        </div>
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>Public?</h2></div>
+            <div class="info_panel_value">{{ task.is_public }}
                 <!--<small>-->
                     <!--{ % if task.is_public %}-->
                         <!--<a href="{ { url_for('task_make_private', id=task.id, next=url_for('view_task', id=task.id)) }}">(make private)</a>-->
@@ -88,11 +175,11 @@
                         <!--<a href="{ { url_for('task_make_public', id=task.id, next=url_for('view_task', id=task.id)) }}">(make public)</a>-->
                     <!--{ % endif %}-->
                 <!--</small>-->
-            </td>
-        </tr>
-        <tr>
-            <td>Tags</td>
-            <td>
+            </div>
+        </div>
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>Tags</h2></div>
+            <div class="info_panel_value">
                 {% for tag in task.tags %}
                     <a href="{{ url_for('view_tag', id=tag.id) }}">{{ tag.value }}</a>
                     {% if can_edit %}
@@ -108,11 +195,11 @@
                            value="{{ url_for('view_task', id=task.id) }}" />
                 </form>
                 {% endif %}
-            </td>
-        </tr>
-        <tr>
-            <td>Authorized Users</td>
-            <td>
+            </div>
+        </div>
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>Authorized Users</h2></div>
+            <div class="info_panel_value">
                 {% for user in task.users %}
                     <a href="{{ url_for('view_user', user_id=user.id) }}">{{ user.email }}</a>
                     {% if can_edit %}
@@ -131,11 +218,11 @@
                 </form>
                 <a href="{{ url_for('pick_user_to_authorize', task_id=task.id) }}">Pick a user</a>
                 {% endif %}
-            </td>
-        </tr>
-        <tr>
-            <td>Depends on</td>
-            <td>
+            </div>
+        </div>
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>Depends on</h2></div>
+            <div class="info_panel_value">
                 {% for dependee in task.dependees %}
                     <a href="{{ url_for('view_task', id=dependee.id) }}" {{ dependee.get_css_class_attr()|safe }}>{{ dependee.summary }} ({{ dependee.id }})</a>
                     {% if can_edit %}
@@ -152,11 +239,11 @@
                 </form>
                 <!--<a href="{ { url_for('pick_dependee_to_add', task_id=task.id) } }">Pick a task</a>-->
                 {% endif %}
-            </td>
-        </tr>
-        <tr>
-            <td>Is depended on by</td>
-            <td>
+            </div>
+        </div>
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>Is depended on by</h2></div>
+            <div class="info_panel_value">
                 {% for dependant in task.dependants %}
                     <a href="{{ url_for('view_task', id=dependant.id) }}" {{ dependant.get_css_class_attr()|safe }}>{{ dependant.summary }} ({{ dependant.id }})</a>
                     {% if can_edit %}
@@ -173,11 +260,11 @@
                 </form>
                 <!--<a href="{ { url_for('pick_dependant_to_add', task_id=task.id) } }">Pick a task</a>-->
                 {% endif %}
-            </td>
-        </tr>
-        <tr>
-            <td>Is prioritized before</td>
-            <td>
+            </div>
+        </div>
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>Is prioritized before</h2></div>
+            <div class="info_panel_value">
                 {% for ptask in task.prioritize_after %}
                     <a href="{{ url_for('view_task', id=ptask.id) }}" {{ ptask.get_css_class_attr()|safe }}>{{ ptask.summary }} ({{ ptask.id }})</a>
                     {% if can_edit %}
@@ -194,11 +281,11 @@
                 </form>
                 <!--<a href="{ { url_for('pick_prioritize_after_to_add', task_id=task.id) } }">Pick a task</a>-->
                 {% endif %}
-            </td>
-        </tr>
-        <tr>
-            <td>Is prioritized after</td>
-            <td>
+            </div>
+        </div>
+        <div class="info_panel_row">
+            <div class="info_panel_label"><h2>Is prioritized after</h2></div>
+            <div class="info_panel_value">
                 {% for ptask in task.prioritize_before %}
                     <a href="{{ url_for('view_task', id=ptask.id) }}" {{ ptask.get_css_class_attr()|safe }}>{{ ptask.summary }} ({{ ptask.id }})</a>
                     {% if can_edit %}
@@ -215,12 +302,13 @@
                 </form>
                 <!--<a href="{ { url_for('pick_prioritize_before_to_add', task_id=task.id) } }">Pick a task</a>-->
                 {% endif %}
-            </td>
-        </tr>
-    </table>
-</td>
-    <td style="vertical-align: top;"><div class="task_description">{{ task.description|gfm if task.description != None }}</div></td>
-</tr></table>
+            </div>
+        </div>
+</div>
+<div class="task_body_panel">
+    <div class="task_description">{{ task.description|gfm if task.description != None }}</div>
+</div>
+</div>
     <p></p>
     {% if can_edit %}
     <a class="btn btn-primary" href="{{ url_for('edit_task', id=task.id) }}">Edit</a>

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -40,22 +40,12 @@
 }
 
 .info_panel_label {
-    line-height: 1;
-
     {#background-color: #3A7734;#}
-}
 
-.info_panel_label h2 {
-
-    box-sizing: border-box;
     font-size: 0.857143em;
     font-style: inherit;
     line-height: 1.33333;
     font-weight: 600;
-    margin-top: 0;
-    margin-bottom: 0;
-
-    {#background-color: #888833;#}
 }
 
 .info_panel_value {
@@ -180,19 +170,19 @@
         <p></p>
 
         <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4"><h2>ID</h2></div>
+            <div class="info_panel_label col-xs-4">ID</div>
             <div class="info_panel_value col-xs-8">{{ task.id }}</div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4"><h2>Summary</h2></div>
+            <div class="info_panel_label col-xs-4">Summary</div>
             <div class="info_panel_value col-xs-8 {{ task.get_css_class()|safe }}">{{ task.summary|d }}</div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4"><h2>Deadline</h2></div>
+            <div class="info_panel_label col-xs-4">Deadline</div>
             <div class="info_panel_value col-xs-8">{{ task.deadline|d }}</div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4"><h2>Done?</h2></div>
+            <div class="info_panel_label col-xs-4">Done?</div>
             <div class="info_panel_value col-xs-8">{{ task.is_done }}
                 {% if can_edit %}
                 <small>
@@ -206,7 +196,7 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4"><h2>Deleted?</h2></div>
+            <div class="info_panel_label col-xs-4">Deleted?</div>
             <div class="info_panel_value col-xs-8">{{ task.is_deleted }}
                 {% if can_edit %}
                 <small>
@@ -220,19 +210,19 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4"><h2>Order #</h2></div>
+            <div class="info_panel_label col-xs-4">Order #</div>
             <div class="info_panel_value col-xs-8">{{ task.order_num if task.order_num != None }}</div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4"><h2>Expected duration</h2></div>
+            <div class="info_panel_label col-xs-4">Expected duration</div>
             <div class="info_panel_value col-xs-8">{{ task.get_expected_duration_for_viewing() }}</div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4"><h2>Expected cost</h2></div>
+            <div class="info_panel_label col-xs-4">Expected cost</div>
             <div class="info_panel_value col-xs-8">${{ task.get_expected_cost_for_viewing() }}</div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4"><h2>Parent Task</h2></div>
+            <div class="info_panel_label col-xs-4">Parent Task</div>
             <div class="info_panel_value col-xs-8">
                 {% if task.parent_id != None %}
                 <a href="{{ url_for('view_task', id=task.parent_id) }}" {{ task.parent.get_css_class_attr()|safe }}>{{ task.parent.summary if task.parent != None }} ({{ task.parent_id if task.parent_id != None }})</a>
@@ -242,7 +232,7 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4"><h2>Public?</h2></div>
+            <div class="info_panel_label col-xs-4">Public?</div>
             <div class="info_panel_value col-xs-8">{{ task.is_public }}
                 <!--<small>-->
                     <!--{ % if task.is_public %}-->
@@ -254,7 +244,7 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4"><h2>Tags</h2></div>
+            <div class="info_panel_label col-xs-4">Tags</div>
             <div class="info_panel_value col-xs-8">
                 <ul class="task_list_group">
                 {% for tag in task.tags %}
@@ -278,7 +268,7 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4"><h2>Authorized Users</h2></div>
+            <div class="info_panel_label col-xs-4">Authorized Users</div>
             <div class="info_panel_value col-xs-8">
                 <ul class="task_list_group">
                 {% for user in task.users %}
@@ -309,7 +299,7 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4"><h2>Depends on</h2></div>
+            <div class="info_panel_label col-xs-4">Depends on</div>
             <div class="info_panel_value col-xs-8">
                 <ul class="task_list_group">
                 {% for dependee in task.dependees %}
@@ -336,7 +326,7 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4"><h2>Is depended on by</h2></div>
+            <div class="info_panel_label col-xs-4">Is depended on by</div>
             <div class="info_panel_value col-xs-8">
                 <ul class="task_list_group">
                 {% for dependant in task.dependants %}
@@ -363,7 +353,7 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4"><h2>Is prioritized before</h2></div>
+            <div class="info_panel_label col-xs-4">Is prioritized before</div>
             <div class="info_panel_value col-xs-8">
                 <ul class="task_list_group">
                 {% for ptask in task.prioritize_after %}
@@ -390,7 +380,7 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4"><h2>Is prioritized after</h2></div>
+            <div class="info_panel_label col-xs-4">Is prioritized after</div>
             <div class="info_panel_value col-xs-8">
                 <ul class="task_list_group">
                 {% for ptask in task.prioritize_before %}

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -248,21 +248,18 @@ a.attachment_list_item {
         {% endif %}
         <p></p>
 
-        <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4">ID</div>
-            <div class="info_panel_value col-xs-8">{{ task.id }}</div>
-        </div>
-        <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4">Summary</div>
-            <div class="info_panel_value col-xs-8 {{ task.get_css_class()|safe }}">{{ task.summary|d }}</div>
-        </div>
-        <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4">Deadline</div>
-            <div class="info_panel_value col-xs-8">{{ task.deadline|d }}</div>
-        </div>
-        <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4">Done?</div>
-            <div class="info_panel_value col-xs-8">{{ task.is_done }}
+    <dl class="dl-horizontal">
+            <dt>ID</dt>
+            <dd>{{ task.id }}</dd>
+
+            <dt>Summary</dt>
+            <dd class="{{ task.get_css_class()|safe }}">{{ task.summary|d }}</dd>
+
+            <dt>Deadline</dt>
+            <dd>{{ task.deadline|d }}</dd>
+
+            <dt>Done?</dt>
+            <dd>{{ task.is_done }}
                 {% if can_edit %}
                 <small>
                     {% if task.is_done %}
@@ -272,11 +269,10 @@ a.attachment_list_item {
                     {% endif %}
                 </small>
                 {% endif %}
-            </div>
-        </div>
-        <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4">Deleted?</div>
-            <div class="info_panel_value col-xs-8">{{ task.is_deleted }}
+            </dd>
+
+            <dt>Deleted?</dt>
+            <dd>{{ task.is_deleted }}
                 {% if can_edit %}
                 <small>
                     {% if task.is_deleted %}
@@ -286,33 +282,28 @@ a.attachment_list_item {
                     {% endif %}
                 </small>
                 {% endif %}
-            </div>
-        </div>
-        <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4">Order #</div>
-            <div class="info_panel_value col-xs-8">{{ task.order_num if task.order_num != None }}</div>
-        </div>
-        <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4">Expected duration</div>
-            <div class="info_panel_value col-xs-8">{{ task.get_expected_duration_for_viewing() }}</div>
-        </div>
-        <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4">Expected cost</div>
-            <div class="info_panel_value col-xs-8">${{ task.get_expected_cost_for_viewing() }}</div>
-        </div>
-        <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4">Parent Task</div>
-            <div class="info_panel_value col-xs-8">
+            </dd>
+
+            <dt>Order #</dt>
+            <dd>{{ task.order_num if task.order_num != None }}</dd>
+
+            <dt>Expected duration</dt>
+            <dd>{{ task.get_expected_duration_for_viewing() }}</dd>
+
+            <dt>Expected cost</dt>
+            <dd>${{ task.get_expected_cost_for_viewing() }}</dd>
+
+            <dt>Parent Task</dt>
+            <dd>
                 {% if task.parent_id != None %}
                 <a href="{{ url_for('view_task', id=task.parent_id) }}" {{ task.parent.get_css_class_attr()|safe }}>{{ task.parent.summary if task.parent != None }} ({{ task.parent_id if task.parent_id != None }})</a>
                 {% else %}
                 None
                 {% endif %}
-            </div>
-        </div>
-        <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4">Public?</div>
-            <div class="info_panel_value col-xs-8">{{ task.is_public }}
+            </dd>
+
+            <dt>Public?</dt>
+            <dd>{{ task.is_public }}
                 <!--<small>-->
                     <!--{ % if task.is_public %}-->
                         <!--<a href="{ { url_for('task_make_private', id=task.id, next=url_for('view_task', id=task.id)) }}">(make private)</a>-->
@@ -320,11 +311,10 @@ a.attachment_list_item {
                         <!--<a href="{ { url_for('task_make_public', id=task.id, next=url_for('view_task', id=task.id)) }}">(make public)</a>-->
                     <!--{ % endif %}-->
                 <!--</small>-->
-            </div>
-        </div>
-        <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4">Tags</div>
-            <div class="info_panel_value col-xs-8">
+            </dd>
+
+            <dt>Tags</dt>
+            <dd>
                 <ul class="task_list_group">
                 {% for tag in task.tags %}
                     <li class="task_list_item">
@@ -344,11 +334,10 @@ a.attachment_list_item {
                 </form>
                 {% endif %}
                 </ul>
-            </div>
-        </div>
-        <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4">Authorized Users</div>
-            <div class="info_panel_value col-xs-8">
+            </dd>
+
+            <dt>Authorized Users</dt>
+            <dd>
                 <ul class="task_list_group">
                 {% for user in task.users %}
                     <li class="task_list_item">
@@ -375,11 +364,10 @@ a.attachment_list_item {
                 </li>
                 {% endif %}
                 </ul>
-            </div>
-        </div>
-        <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4">Depends on</div>
-            <div class="info_panel_value col-xs-8">
+            </dd>
+
+            <dt>Depends on</dt>
+            <dd>
                 <ul class="task_list_group">
                 {% for dependee in task.dependees %}
                 <li class="task_list_item">
@@ -402,11 +390,10 @@ a.attachment_list_item {
                 <!--<a href="{ { url_for('pick_dependee_to_add', task_id=task.id) } }">Pick a task</a>-->
                 {% endif %}
                 </ul>
-            </div>
-        </div>
-        <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4">Is depended on by</div>
-            <div class="info_panel_value col-xs-8">
+            </dd>
+
+            <dt>Is depended on by</dt>
+            <dd>
                 <ul class="task_list_group">
                 {% for dependant in task.dependants %}
                 <li class="task_list_item">
@@ -429,11 +416,10 @@ a.attachment_list_item {
                 <!--<a href="{ { url_for('pick_dependant_to_add', task_id=task.id) } }">Pick a task</a>-->
                 {% endif %}
                 </ul>
-            </div>
-        </div>
-        <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4">Is prioritized before</div>
-            <div class="info_panel_value col-xs-8">
+            </dd>
+
+            <dt>Is prioritized before</dt>
+            <dd>
                 <ul class="task_list_group">
                 {% for ptask in task.prioritize_after %}
                 <li class="task_list_item">
@@ -456,11 +442,10 @@ a.attachment_list_item {
                 <!--<a href="{ { url_for('pick_prioritize_after_to_add', task_id=task.id) } }">Pick a task</a>-->
                 {% endif %}
                 </ul>
-            </div>
-        </div>
-        <div class="info_panel_row">
-            <div class="info_panel_label col-xs-4">Is prioritized after</div>
-            <div class="info_panel_value col-xs-8">
+            </dd>
+
+            <dt>Is prioritized after</dt>
+            <dd>
                 <ul class="task_list_group">
                 {% for ptask in task.prioritize_before %}
                 <li class="task_list_item">
@@ -483,8 +468,8 @@ a.attachment_list_item {
                 <!--<a href="{ { url_for('pick_prioritize_before_to_add', task_id=task.id) } }">Pick a task</a>-->
                 {% endif %}
                 </ul>
-            </div>
-        </div>
+            </dd>
+    </dl>
     <p></p>
     {% if can_edit %}
     <a class="btn btn-primary" href="{{ url_for('edit_task', id=task.id) }}">Edit</a>

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -29,6 +29,10 @@
     border-radius: 4px;
 }
 
+.info_panel input {
+    width: 5em;
+}
+
 .info_panel_row {
     display: flex;
     flex-wrap: wrap;

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -226,7 +226,9 @@
         <div class="info_panel_row">
             <div class="info_panel_label"><h2>Authorized Users</h2></div>
             <div class="info_panel_value">
+                <ul class="task_list_group">
                 {% for user in task.users %}
+                    <li class="task_list_item">
                     <a href="{{ url_for('view_user', user_id=user.id) }}">{{ user.email }}</a>
                     {% if can_edit %}
                     {% if task.users.__len__() > 1 %}
@@ -235,99 +237,129 @@
                     </a>
                     {% endif %}
                     {% endif %}
+                    </li>
                 {% endfor %}
                 {% if can_edit %}
+                <li class="task_list_item">
                 <form action="{{ url_for('authorize_user_for_task', task_id=task.id) }}" method="post">
                     <input type="text" name="email" />
                     <input type="hidden" name="next_url"
                            value="{{ url_for('view_task', id=task.id) }}" />
                 </form>
+                </li>
+                <li class="task_list_item">
                 <a href="{{ url_for('pick_user_to_authorize', task_id=task.id) }}">Pick a user</a>
+                </li>
                 {% endif %}
+                </ul>
             </div>
         </div>
         <div class="info_panel_row">
             <div class="info_panel_label"><h2>Depends on</h2></div>
             <div class="info_panel_value">
+                <ul class="task_list_group">
                 {% for dependee in task.dependees %}
+                <li class="task_list_item">
                     <a href="{{ url_for('view_task', id=dependee.id) }}" {{ dependee.get_css_class_attr()|safe }}>{{ dependee.summary }} ({{ dependee.id }})</a>
                     {% if can_edit %}
                     <a href="{{ url_for('remove_dependee_from_task', task_id=task.id, dependee_id=dependee.id) }}">
                         <span class="glyphicon glyphicon-remove text-danger"></span>
                     </a>
                     {% endif %}
+                </li>
                 {% endfor %}
                 {% if can_edit %}
+                <li class="task_list_item">
                 <form action="{{ url_for('add_dependee_to_task', task_id=task.id) }}" method="post">
                     <input type="text" name="dependee_id" />
                     <input type="hidden" name="next_url"
                            value="{{ url_for('view_task', id=task.id) }}" />
                 </form>
+                </li>
                 <!--<a href="{ { url_for('pick_dependee_to_add', task_id=task.id) } }">Pick a task</a>-->
                 {% endif %}
+                </ul>
             </div>
         </div>
         <div class="info_panel_row">
             <div class="info_panel_label"><h2>Is depended on by</h2></div>
             <div class="info_panel_value">
+                <ul class="task_list_group">
                 {% for dependant in task.dependants %}
+                <li class="task_list_item">
                     <a href="{{ url_for('view_task', id=dependant.id) }}" {{ dependant.get_css_class_attr()|safe }}>{{ dependant.summary }} ({{ dependant.id }})</a>
                     {% if can_edit %}
                     <a href="{{ url_for('remove_dependant_from_task', task_id=task.id, dependant_id=dependant.id) }}">
                         <span class="glyphicon glyphicon-remove text-danger"></span>
                     </a>
                     {% endif %}
+                </li>
                 {% endfor %}
                 {% if can_edit %}
+                <li class="task_list_item">
                 <form action="{{ url_for('add_dependant_to_task', task_id=task.id) }}" method="post">
                     <input type="text" name="dependant_id" />
                     <input type="hidden" name="next_url"
                            value="{{ url_for('view_task', id=task.id) }}" />
                 </form>
+                </li>
                 <!--<a href="{ { url_for('pick_dependant_to_add', task_id=task.id) } }">Pick a task</a>-->
                 {% endif %}
+                </ul>
             </div>
         </div>
         <div class="info_panel_row">
             <div class="info_panel_label"><h2>Is prioritized before</h2></div>
             <div class="info_panel_value">
+                <ul class="task_list_group">
                 {% for ptask in task.prioritize_after %}
+                <li class="task_list_item">
                     <a href="{{ url_for('view_task', id=ptask.id) }}" {{ ptask.get_css_class_attr()|safe }}>{{ ptask.summary }} ({{ ptask.id }})</a>
                     {% if can_edit %}
                     <a href="{{ url_for('remove_prioritize_after_from_task', task_id=task.id, prioritize_after_id=ptask.id) }}">
                         <span class="glyphicon glyphicon-remove text-danger"></span>
                     </a>
                     {% endif %}
+                </li>
                 {% endfor %}
                 {% if can_edit %}
+                <li class="task_list_item">
                 <form action="{{ url_for('add_prioritize_after_to_task', task_id=task.id) }}" method="post">
                     <input type="text" name="prioritize_after_id" />
                     <input type="hidden" name="next_url"
                            value="{{ url_for('view_task', id=task.id) }}" />
                 </form>
+                </li>
                 <!--<a href="{ { url_for('pick_prioritize_after_to_add', task_id=task.id) } }">Pick a task</a>-->
                 {% endif %}
+                </ul>
             </div>
         </div>
         <div class="info_panel_row">
             <div class="info_panel_label"><h2>Is prioritized after</h2></div>
             <div class="info_panel_value">
+                <ul class="task_list_group">
                 {% for ptask in task.prioritize_before %}
+                <li class="task_list_item">
                     <a href="{{ url_for('view_task', id=ptask.id) }}" {{ ptask.get_css_class_attr()|safe }}>{{ ptask.summary }} ({{ ptask.id }})</a>
                     {% if can_edit %}
                     <a href="{{ url_for('remove_prioritize_before_from_task', task_id=task.id, prioritize_before_id=ptask.id) }}">
                         <span class="glyphicon glyphicon-remove text-danger"></span>
                     </a>
                     {% endif %}
+                </li>
                 {% endfor %}
                 {% if can_edit %}
+                <li class="task_list_item">
                 <form action="{{ url_for('add_prioritize_before_to_task', task_id=task.id) }}" method="post">
                     <input type="text" name="prioritize_before_id" />
                     <input type="hidden" name="next_url"
                            value="{{ url_for('view_task', id=task.id) }}" />
                 </form>
+                </li>
                 <!--<a href="{ { url_for('pick_prioritize_before_to_add', task_id=task.id) } }">Pick a task</a>-->
                 {% endif %}
+                </ul>
             </div>
         </div>
 </div>

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -34,6 +34,7 @@
 .info_panel {
     width: calc(12px + min(450px, 30%));
     background-color: #1c9c1a;
+    padding: 10px;
 }
 
 .info_panel_row {

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -426,13 +426,6 @@
     <p><a class="btn btn-default" href="{{ url_for('new_task', parent_id=task.id) }}"><span class="glyphicon glyphicon-plus"></span> New Child Task</a></p>
     {% endif %}
 
-</div>
-<div class="task_body_panel">
-    <div class="task_description">{{ task.description|gfm if task.description != None }}</div>
-</div>
-</div>
-</div>
-<div>
     <p>
         {%- if show_deleted %}
         <a href="{{ url_for('show_hide_deleted', show_deleted=0, next=url_for('view_task', id=task.id)) }}">hide deleted</a>
@@ -448,6 +441,12 @@
         {% endif -%}
     </p>
     <p><a class="btn btn-default" href="{{ url_for('view_task_hierarchy', id=task.id) }}">hierarchy view</a></p>
+
+</div>
+<div class="task_body_panel">
+    <div class="task_description">{{ task.description|gfm if task.description != None }}</div>
+</div>
+</div>
 </div>
 <div class="note_panel">
     <h4>Notes</h4>

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -11,7 +11,6 @@
     border-color: #000000;
     padding: 10px; /* csslint allow: box-model */
     {#width: 870px; /* csslint allow: box-model */#}
-    background-color: #9C1A1C;
 }
 
 .task_info {
@@ -33,8 +32,10 @@
 
 .info_panel {
     width: calc(12px + min(450px, 30%));
-    background-color: #1c9c1a;
+    background-color: #f5f5f5;
     padding: 10px;
+    border: solid 1px #cccccc;
+    border-radius: 4px;
 }
 
 .info_panel_row {
@@ -100,7 +101,6 @@
 }
 
 .note_panel {
-    background-color: #1a1c9c;
     padding: 10px;
 }
 </style>

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -40,16 +40,6 @@
 }
 
 .info_panel_label {
-
-    position: relative;
-    -moz-box-flex: 1;
-    flex-grow: 1;
-    box-sizing: border-box;
-    padding-right: 24px;
-    min-width: 90px;
-    width: 33.33%;
-    padding-top: 8px;
-    max-width: 120px;
     line-height: 1;
 
     {#background-color: #3A7734;#}
@@ -70,13 +60,6 @@
 
 .info_panel_value {
     {#background-color: #86989B;#}
-
-    -moz-box-flex: 1;
-    flex-grow: 1;
-    width: 66.67%;
-    box-sizing: border-box;
-    margin-top: 2px;
-    margin-bottom: 2px;
 }
 
 .task_body_panel {
@@ -197,20 +180,20 @@
         <p></p>
 
         <div class="info_panel_row">
-            <div class="info_panel_label"><h2>ID</h2></div>
-            <div class="info_panel_value">{{ task.id }}</div>
+            <div class="info_panel_label col-xs-4"><h2>ID</h2></div>
+            <div class="info_panel_value col-xs-8">{{ task.id }}</div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label"><h2>Summary</h2></div>
-            <div class="info_panel_value {{ task.get_css_class()|safe }}">{{ task.summary|d }}</div>
+            <div class="info_panel_label col-xs-4"><h2>Summary</h2></div>
+            <div class="info_panel_value col-xs-8 {{ task.get_css_class()|safe }}">{{ task.summary|d }}</div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label"><h2>Deadline</h2></div>
-            <div class="info_panel_value">{{ task.deadline|d }}</div>
+            <div class="info_panel_label col-xs-4"><h2>Deadline</h2></div>
+            <div class="info_panel_value col-xs-8">{{ task.deadline|d }}</div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label"><h2>Done?</h2></div>
-            <div class="info_panel_value">{{ task.is_done }}
+            <div class="info_panel_label col-xs-4"><h2>Done?</h2></div>
+            <div class="info_panel_value col-xs-8">{{ task.is_done }}
                 {% if can_edit %}
                 <small>
                     {% if task.is_done %}
@@ -223,8 +206,8 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label"><h2>Deleted?</h2></div>
-            <div class="info_panel_value">{{ task.is_deleted }}
+            <div class="info_panel_label col-xs-4"><h2>Deleted?</h2></div>
+            <div class="info_panel_value col-xs-8">{{ task.is_deleted }}
                 {% if can_edit %}
                 <small>
                     {% if task.is_deleted %}
@@ -237,20 +220,20 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label"><h2>Order #</h2></div>
-            <div class="info_panel_value">{{ task.order_num if task.order_num != None }}</div>
+            <div class="info_panel_label col-xs-4"><h2>Order #</h2></div>
+            <div class="info_panel_value col-xs-8">{{ task.order_num if task.order_num != None }}</div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label"><h2>Expected duration</h2></div>
-            <div class="info_panel_value">{{ task.get_expected_duration_for_viewing() }}</div>
+            <div class="info_panel_label col-xs-4"><h2>Expected duration</h2></div>
+            <div class="info_panel_value col-xs-8">{{ task.get_expected_duration_for_viewing() }}</div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label"><h2>Expected cost</h2></div>
-            <div class="info_panel_value">${{ task.get_expected_cost_for_viewing() }}</div>
+            <div class="info_panel_label col-xs-4"><h2>Expected cost</h2></div>
+            <div class="info_panel_value col-xs-8">${{ task.get_expected_cost_for_viewing() }}</div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label"><h2>Parent Task</h2></div>
-            <div class="info_panel_value">
+            <div class="info_panel_label col-xs-4"><h2>Parent Task</h2></div>
+            <div class="info_panel_value col-xs-8">
                 {% if task.parent_id != None %}
                 <a href="{{ url_for('view_task', id=task.parent_id) }}" {{ task.parent.get_css_class_attr()|safe }}>{{ task.parent.summary if task.parent != None }} ({{ task.parent_id if task.parent_id != None }})</a>
                 {% else %}
@@ -259,8 +242,8 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label"><h2>Public?</h2></div>
-            <div class="info_panel_value">{{ task.is_public }}
+            <div class="info_panel_label col-xs-4"><h2>Public?</h2></div>
+            <div class="info_panel_value col-xs-8">{{ task.is_public }}
                 <!--<small>-->
                     <!--{ % if task.is_public %}-->
                         <!--<a href="{ { url_for('task_make_private', id=task.id, next=url_for('view_task', id=task.id)) }}">(make private)</a>-->
@@ -271,8 +254,8 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label"><h2>Tags</h2></div>
-            <div class="info_panel_value">
+            <div class="info_panel_label col-xs-4"><h2>Tags</h2></div>
+            <div class="info_panel_value col-xs-8">
                 <ul class="task_list_group">
                 {% for tag in task.tags %}
                     <li class="task_list_item">
@@ -295,8 +278,8 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label"><h2>Authorized Users</h2></div>
-            <div class="info_panel_value">
+            <div class="info_panel_label col-xs-4"><h2>Authorized Users</h2></div>
+            <div class="info_panel_value col-xs-8">
                 <ul class="task_list_group">
                 {% for user in task.users %}
                     <li class="task_list_item">
@@ -326,8 +309,8 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label"><h2>Depends on</h2></div>
-            <div class="info_panel_value">
+            <div class="info_panel_label col-xs-4"><h2>Depends on</h2></div>
+            <div class="info_panel_value col-xs-8">
                 <ul class="task_list_group">
                 {% for dependee in task.dependees %}
                 <li class="task_list_item">
@@ -353,8 +336,8 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label"><h2>Is depended on by</h2></div>
-            <div class="info_panel_value">
+            <div class="info_panel_label col-xs-4"><h2>Is depended on by</h2></div>
+            <div class="info_panel_value col-xs-8">
                 <ul class="task_list_group">
                 {% for dependant in task.dependants %}
                 <li class="task_list_item">
@@ -380,8 +363,8 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label"><h2>Is prioritized before</h2></div>
-            <div class="info_panel_value">
+            <div class="info_panel_label col-xs-4"><h2>Is prioritized before</h2></div>
+            <div class="info_panel_value col-xs-8">
                 <ul class="task_list_group">
                 {% for ptask in task.prioritize_after %}
                 <li class="task_list_item">
@@ -407,8 +390,8 @@
             </div>
         </div>
         <div class="info_panel_row">
-            <div class="info_panel_label"><h2>Is prioritized after</h2></div>
-            <div class="info_panel_value">
+            <div class="info_panel_label col-xs-4"><h2>Is prioritized after</h2></div>
+            <div class="info_panel_value col-xs-8">
                 <ul class="task_list_group">
                 {% for ptask in task.prioritize_before %}
                 <li class="task_list_item">

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -362,17 +362,17 @@
                 </ul>
             </div>
         </div>
-</div>
-<div class="task_body_panel">
-    <div class="task_description">{{ task.description|gfm if task.description != None }}</div>
-</div>
-</div>
     <p></p>
     {% if can_edit %}
     <a class="btn btn-primary" href="{{ url_for('edit_task', id=task.id) }}">Edit</a>
     <p></p>
     <a class="btn btn-danger btn-xs" href="{{ url_for('convert_task_to_tag', id=task.id) }}">Convert to tag</a>
     {% endif %}
+</div>
+<div class="task_body_panel">
+    <div class="task_description">{{ task.description|gfm if task.description != None }}</div>
+</div>
+</div>
 </div>
 <div>
     <h4>Child Tasks</h4>

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -90,6 +90,9 @@
     display: block;
 }
 
+.child_task_section {
+}
+
 .note_panel {
     padding: 10px;
 }
@@ -97,6 +100,9 @@
 
 {% endblock %}
 {% block content %}
+
+{% set can_edit = ops.user_can_edit_task(task, current_user) %}
+
 <div class="container">
 <div class="top_panel">
     <ol class="breadcrumb">
@@ -112,9 +118,47 @@
     <h1 class="info_panel_value {{ task.get_css_class()|safe }}">{{ task.summary|d }}</h1>
     <p><br/></p>
 </div>
+
+<div class="task_body_panel col-md-8">
+    <div class="task_description">{{ task.description|gfm if task.description != None }}</div>
+
+    <div class="child_task_section">
+    <hr/>
+    {%  if (show_hierarchy and descendants) or
+            (not show_hierarchy and pager.items) %}
+    <h4>Child Tasks</h4>
+    {% if show_hierarchy %}
+        {{ render_task_table(descendants, task, cycle,
+            page_url=url_for('view_task', id=task.id),
+            child_task_view='view_task',
+            show_move_links=True,
+            show_new_task_form=False, new_task_parent=task) }}
+    {% else %}
+        {% if pager.pages > 1 %}
+            {% include 'page_links.fragment.html' %}
+        {% endif %}
+
+        {{ render_task_table(pager.items, task, cycle,
+            page_url=url_for('view_task', id=task.id),
+            child_task_view='view_task',
+            show_move_links=True,
+            show_new_task_form=False, new_task_parent=task, show_order_num=True) }}
+
+        {% if pager.pages > 1 %}
+            {% include 'page_links.fragment.html' %}
+        {% endif %}
+    {% endif %} {# show_hierarchy #}
+    {% endif %}  {# descendants or pager.items #}
+
+        {% if can_edit %}
+        <p><a class="btn btn-default" href="{{ url_for('new_task', parent_id=task.id) }}"><span class="glyphicon glyphicon-plus"></span> New Child Task</a></p>
+        {% endif %}
+    </div>
+
+</div>
+
 <div class="info_panel col-md-4">
 
-        {% set can_edit = ops.user_can_edit_task(task, current_user) %}
         {% if can_edit %}
         <a class="btn btn-primary" href="{{ url_for('edit_task', id=task.id) }}">Edit</a>
         {% endif %}
@@ -387,34 +431,6 @@
     <a class="btn btn-danger btn-xs" href="{{ url_for('convert_task_to_tag', id=task.id) }}">Convert to tag</a>
     {% endif %}
 
-
-    <h4>Child Tasks</h4>
-    {% if show_hierarchy %}
-        {{ render_task_table(descendants, task, cycle,
-            page_url=url_for('view_task', id=task.id),
-            child_task_view='view_task',
-            show_move_links=True,
-            show_new_task_form=False, new_task_parent=task) }}
-    {% else %}
-        {% if pager.pages > 1 %}
-            {% include 'page_links.fragment.html' %}
-        {% endif %}
-
-        {{ render_task_table(pager.items, task, cycle,
-            page_url=url_for('view_task', id=task.id),
-            child_task_view='view_task',
-            show_move_links=True,
-            show_new_task_form=False, new_task_parent=task, show_order_num=True) }}
-
-        {% if pager.pages > 1 %}
-            {% include 'page_links.fragment.html' %}
-        {% endif %}
-    {% endif %}
-
-    {% if can_edit %}
-    <p><a class="btn btn-default" href="{{ url_for('new_task', parent_id=task.id) }}"><span class="glyphicon glyphicon-plus"></span> New Child Task</a></p>
-    {% endif %}
-
     <p>
         {%- if show_deleted %}
         <a href="{{ url_for('show_hide_deleted', show_deleted=0, next=url_for('view_task', id=task.id)) }}">hide deleted</a>
@@ -432,9 +448,7 @@
     <p><a class="btn btn-default" href="{{ url_for('view_task_hierarchy', id=task.id) }}">hierarchy view</a></p>
 
 </div>
-<div class="task_body_panel col-md-8">
-    <div class="task_description">{{ task.description|gfm if task.description != None }}</div>
-</div>
+
 <div class="note_panel col-md-12">
     <h4>Notes</h4>
     <table class="task_notes">

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -2,6 +2,27 @@
 {% from 'task_table.t.html' import render_task_table %}
 {% block title %}{{ task.summary if task.summary != None }} - {{ super() }}{% endblock %}
 {% block header_sub_text %}{{ task.summary if task.summary != None }}{% endblock %}
+{% block link_css %}
+
+<style>
+
+.task_description
+{
+    border-color: #000000;
+    padding: 10px; /* csslint allow: box-model */
+    width: 870px; /* csslint allow: box-model */
+    background-color: #9C1A1C;
+}
+
+.task_info {
+    max-width: 1em;
+    background-color: #86989B;
+    {#display: block;#}
+}
+
+</style>
+
+{% endblock %}
 {% block content %}
 <div class="container">
 <div>
@@ -10,10 +31,11 @@
     <a class="btn btn-primary" href="{{ url_for('edit_task', id=task.id) }}">Edit</a>
     {% endif %}
     <p></p>
+<table>
+<tr><td style="vertical-align: top;">
     <table class="task_info">
         <tr><td>ID</td><td>{{ task.id }}</td></tr>
         <tr><td>Summary</td><td{{ task.get_css_class_attr()|safe }}>{{ task.summary|d }}</td></tr>
-        <tr><td>Description</td><td><div class="task_description">{{ task.description|gfm if task.description != None }}</div></td></tr>
         <tr><td>Deadline</td><td>{{ task.deadline|d }}</td></tr>
         <tr>
             <td>Done?</td>
@@ -196,6 +218,9 @@
             </td>
         </tr>
     </table>
+</td>
+    <td style="vertical-align: top;"><div class="task_description">{{ task.description|gfm if task.description != None }}</div></td>
+</tr></table>
     <p></p>
     {% if can_edit %}
     <a class="btn btn-primary" href="{{ url_for('edit_task', id=task.id) }}">Edit</a>

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -73,6 +73,10 @@
     padding: 10px;
 }
 
+.note_panel form textarea {
+    width: 100%;
+}
+
 .attachment_list {
     padding-left: 0;
     margin-bottom: 20px;
@@ -508,35 +512,26 @@ a.attachment_list_item {
 
 <div class="note_panel col-md-12">
     <h4>Notes</h4>
-    <table class="task_notes">
-        <thead>
-        <tr>
-            <th>ID</th>
-            <th>Timestamp</th>
-            <th>Content</th>
-        </tr>
-        </thead>
+    <div class="task_notes list-group">
         {% for note in task.notes %}
-        <tr>
-            <td>{{ note.id }}</td>
-            <td>{{ note.timestamp }}</td>
-            <td class="note_content">{{ note.content|gfm if note.content != None }}</td>
-        </tr>
+        <div class="list-group-item row">
+            <div class="col-md-1">{{ note.id }}</div>
+            <div class="col-md-3">{{ note.timestamp }}</div>
+            <div class="note_content col-md-8">{{ note.content|gfm if note.content != None }}</div>
+        </div>
         {% endfor %}
         {% if can_edit %}
-        <tr>
-            <td></td>
-            <td></td>
-            <td>
+        <div class="list-group-item row">
+            <div class="col-md-12">
                 <form action="{{ url_for('new_note') }}" method="post">
                     <input type="hidden" name="task_id" value="{{ task.id }}" />
                     <textarea name="content"></textarea><br/>
                     <input type="submit" value="Add New Note">
                 </form>
-            </td>
-        </tr>
+            </div>
+        </div>
         {% endif %}
-    </table>
+    </div>
 
 </div>
 

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -182,13 +182,13 @@ a.attachment_list_item {
         <h4>Attachments</h4>
         <div class="attachment_list">
             {% for att in task.attachments %}
-            <a class="attachment_list_item" href="{{ url_for('get_attachment', aid=att.id, x=att.filename) }}">
-                <div class="attachment_header "><span class="glyphicon glyphicon-file"></span>&nbsp;{{ att.filename if att.filename != None }} ({{ att.id }})</div>
-                <div class="attachment_timestamp ">{{ att.timestamp }}</div>
-                <div class="attachment_description ">{{ att.description }}</div>
+            <a class="attachment_list_item row" href="{{ url_for('get_attachment', aid=att.id, x=att.filename) }}">
+                <div class="attachment_header col-md-3"><span class="glyphicon glyphicon-file"></span>&nbsp;{{ att.filename if att.filename != None }} ({{ att.id }})</div>
+                <div class="attachment_timestamp col-md-4">{{ att.timestamp }}</div>
+                <div class="attachment_description col-md-5">{{ att.description }}</div>
             </a>
             {% endfor %}
-            <div class="attachment_list_item">
+            <div class="attachment_list_item row">
                 <form action="{{ url_for('new_attachment') }}" method="post" enctype="multipart/form-data">
                     <input type="hidden" name="task_id" value="{{ task.id }}">
                     <p style="margin-top: 15px"><input type="file" name="filename" /></p>

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -19,19 +19,10 @@
     {#display: block;#}
 }
 
-.panel_container {
-    flex-wrap: nowrap;
-    height: 100%;
-    -moz-box-align: initial;
-    align-items: initial;
-
-    display: flex;
-    max-width: 100%;
-    position: relative;
+.top_panel {
 }
 
 .info_panel {
-    width: calc(12px + min(450px, 30%));
     background-color: #f5f5f5;
     padding: 10px;
     border: solid 1px #cccccc;
@@ -89,7 +80,6 @@
 }
 
 .task_body_panel {
-    width: calc(-12px + min(798px, 70%))
 }
 
 .task_list_group {
@@ -108,8 +98,7 @@
 {% endblock %}
 {% block content %}
 <div class="container">
-<div>
-
+<div class="top_panel">
     <ol class="breadcrumb">
     {% macro breadcrumb_parent(t) -%}
         {% if t.parent != None %}
@@ -122,9 +111,8 @@
     </ol>
     <h1 class="info_panel_value {{ task.get_css_class()|safe }}">{{ task.summary|d }}</h1>
     <p><br/></p>
-
-<div class="panel_container">
-<div class="info_panel">
+</div>
+<div class="info_panel col-md-4">
 
         {% set can_edit = ops.user_can_edit_task(task, current_user) %}
         {% if can_edit %}
@@ -444,12 +432,10 @@
     <p><a class="btn btn-default" href="{{ url_for('view_task_hierarchy', id=task.id) }}">hierarchy view</a></p>
 
 </div>
-<div class="task_body_panel">
+<div class="task_body_panel col-md-8">
     <div class="task_description">{{ task.description|gfm if task.description != None }}</div>
 </div>
-</div>
-</div>
-<div class="note_panel">
+<div class="note_panel col-md-12">
     <h4>Notes</h4>
     <table class="task_notes">
         <thead>

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -101,6 +101,7 @@
 
 .note_panel {
     background-color: #1a1c9c;
+    padding: 10px;
 }
 </style>
 

--- a/templates/task.t.html
+++ b/templates/task.t.html
@@ -89,6 +89,14 @@
     width: calc(-12px + min(798px, 70%))
 }
 
+.task_list_group {
+    padding-left: 0px;
+}
+
+.task_list_item {
+    display: block;
+}
+
 </style>
 
 {% endblock %}
@@ -194,13 +202,16 @@
         <div class="info_panel_row">
             <div class="info_panel_label"><h2>Tags</h2></div>
             <div class="info_panel_value">
+                <ul class="task_list_group">
                 {% for tag in task.tags %}
+                    <li class="task_list_item">
                     <a href="{{ url_for('view_tag', id=tag.id) }}">{{ tag.value }}</a>
                     {% if can_edit %}
                     <a href="{{ url_for('delete_tag_from_task', id=task.id, tag_id=tag.id) }}">
                         <span class="glyphicon glyphicon-remove text-danger"></span>
                     </a>
                     {% endif %}
+                    </li>
                 {% endfor %}
                 {% if can_edit %}
                 <form action="{{ url_for('add_tag_to_task', id=task.id) }}" method="post">
@@ -209,6 +220,7 @@
                            value="{{ url_for('view_task', id=task.id) }}" />
                 </form>
                 {% endif %}
+                </ul>
             </div>
         </div>
         <div class="info_panel_row">

--- a/templates/task_table.t.html
+++ b/templates/task_table.t.html
@@ -8,7 +8,7 @@
                 show_done_links=True, show_delete_links=True,
                 show_new_task_form=False, new_task_parent=None,
                 indent=True) -%}
-    <table class="task_children">
+    <table class="task_children col-md-12">
         {% set odd_even = cycle(['odd', 'even']).__next__ %}
         <thead>
         <tr>

--- a/templates/task_table.t.html
+++ b/templates/task_table.t.html
@@ -59,7 +59,7 @@
                         else child.depth)
                             if indent
                             else 0 %}
-            <td style="padding-left: {{depth*1.5}}em" {{ child.get_css_class_attr()|safe }}>
+            <td class="task_table_summary {{ child.get_css_class()|safe }}">
                 <a href="{{ url_for(child_task_view, id=child.id) }}">{{ child.summary }}</a>
             </td>
             {% if show_deadline %}

--- a/tudor.py
+++ b/tudor.py
@@ -857,6 +857,7 @@ def get_secret_key(secret_key, secret_key_file):
 
 
 def main(argv):
+    import os
     arg_config = get_config_from_command_line(argv)
 
     arg_config.DB_URI = get_db_uri(arg_config.DB_URI, arg_config.DB_URI_FILE)
@@ -869,6 +870,7 @@ def main(argv):
 
     print(f'__version__: {__version__}', file=sys.stderr)
     print(f'__revision__: {__revision__}', file=sys.stderr)
+    print(f'getcwd(): {os.getcwd()}', file=sys.stderr)
     print(f'DEBUG: {arg_config.DEBUG}', file=sys.stderr)
     print(f'HOST: {arg_config.HOST}', file=sys.stderr)
     print(f'PORT: {arg_config.PORT}', file=sys.stderr)

--- a/view/layer.py
+++ b/view/layer.py
@@ -371,7 +371,8 @@ class ViewLayer(object):
         task_id = request.form['task_id']
 
         f = request.files['filename']
-        if f is None or not f.filename or not self.ll.allowed_file(f.filename):
+        if f is None or not f.filename:
+            # or not self.ll.allowed_file(f.filename):
             raise BadRequest('Invalid file')
 
         if 'description' in request.form:


### PR DESCRIPTION
This PR re-arranges the view-task page. It replaces tables and tags like h2 with a more responsive layout via bootstrap css and components. It adds breadcrumbs to the page. It makes the description central and moves the other task info to a side panel. It changes the layout of attachments and notes so that they are more compact on smaller screens. It moves the various sections of the page around.

This is almost all markup and layout. There is almost no change to the python code, except to allow all file types to be attached.