### PR TITLE
Fix migration version tracking and startup errors

### DIFF
--- a/persistence/migration.py
+++ b/persistence/migration.py
@@ -1,4 +1,19 @@
+import os
+import re
 from sqlalchemy import text
+
+
+def get_highest_migration_version():
+    from packaging.version import parse
+    migrations_dir = os.path.join(os.path.dirname(__file__), 'migrations')
+    highest = None
+    for fname in os.listdir(migrations_dir):
+        m = re.match(r'^v(\d+\.\d+)\.sql$', fname)
+        if m:
+            v = parse(m.group(1))
+            if highest is None or v > highest:
+                highest = v
+    return highest.public if highest else None
 
 
 def auto_migrate(pl, desired_version, *, _fs=None, _print=None):
@@ -38,19 +53,10 @@ def auto_migrate(pl, desired_version, *, _fs=None, _print=None):
                 script = f.read()
                 _print(f'Running migration script for v{current_version}')
                 pl.execute(text(script))
-                pl.commit()
         else:
             _print(f'No migration script found for v{current_version}')
-            pl.execute(text("update option "
-                            f"set value = '{current_version}' "
-                            "where key = '__version__';"))
-            pl.commit()
-
-    current_version = pl.get_schema_version().value
-    if current_version != desired_version:
-        # set the value
         pl.execute(text("update option "
-                        f"set value = '{desired_version}' "
+                        f"set value = '{current_version}' "
                         "where key = '__version__';"))
         pl.commit()
 

--- a/persistence/migrations/v0.14.sql
+++ b/persistence/migrations/v0.14.sql
@@ -1,4 +1,4 @@
 ALTER TABLE task ALTER COLUMN description TYPE text;
 ALTER TABLE tag ALTER COLUMN description TYPE text;
-ALTER TABLE comment ALTER COLUMN content TYPE text;
+ALTER TABLE note ALTER COLUMN content TYPE text;
 ALTER TABLE attachment ALTER COLUMN description TYPE text;

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ Flask-Login==0.6.3
 Flask-SQLAlchemy==3.1.1
 Werkzeug==3.1.8
 psycopg2-binary==2.9.11
+setuptools

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,7 +14,7 @@ class MainFunctionTests(unittest.TestCase):
             app = mock_generate.return_value
             from models.option_base import OptionBase
             app.pl.get_schema_version.return_value = \
-                OptionBase('__version__', '0.13')
+                OptionBase('__version__', '0.16')
             folder = os.path.abspath(
                 os.path.join(os.path.dirname(__file__), '..'))
 

--- a/tudor.py
+++ b/tudor.py
@@ -927,9 +927,11 @@ def main(argv):
         if not current:
             current = '0.0'
         current = parse(parse(current).base_version)
-        try:
-            desired = parse(parse(__version__).base_version)
-        except InvalidVersion:
+        from persistence.migration import get_highest_migration_version
+        highest = get_highest_migration_version()
+        if highest:
+            desired = parse(highest)
+        else:
             desired = current
         if current < desired:
             print(f'Wrong DB schema version. Expected {desired.public} but got '


### PR DESCRIPTION
## Summary

- Fix migration to update \`__version__\` atomically with each script's schema changes, preventing scripts from being re-run after a partial migration failure
- Derive migration target from the highest-numbered script in the migrations folder rather than the app's \`__version__\`, decoupling migrations from the software version
- Add \`setuptools\` to requirements to fix gunicorn startup failure on Python 3.12 (\`No module named pkg_resources\`)
- Fix \`v0.14.sql\` to reference the correct table name after the notes→comments rename

## Test plan

- [ ] Verify app starts and migrates successfully from a v0.9 database
- [ ] Verify that a failed migration (e.g. mid-run crash) correctly retries only the failed step on next startup
- [ ] Verify gunicorn starts without \`pkg_resources\` error on Python 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)