### PR TITLE
Fix container startup errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache bash
 
 RUN apk add --virtual .build-deps gcc musl-dev libffi-dev postgresql-dev g++ && \
     pip install --upgrade pip setuptools wheel  --no-cache-dir && \
-    pip install gunicorn==20.1.0                --no-cache-dir && \
+    pip install gunicorn==25.3.0                --no-cache-dir && \
     pip install psycopg2==2.9.11                --no-cache-dir && \
     apk --purge del .build-deps
 RUN apk add libpq

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 FROM python:3.12-alpine
 
-ARG VERSION=unknown
-ARG REVISION=unknown
-
-LABEL Name=tudor
-LABEL Version=$VERSION
-
 RUN mkdir -p /opt/tudor
 
 WORKDIR /opt/tudor
+
+EXPOSE 8080
+ENV TUDOR_PORT=8080 \
+    TUDOR_HOST=0.0.0.0
 
 RUN apk add --no-cache bash
 
@@ -45,11 +43,17 @@ COPY static static
 COPY templates templates
 COPY view view
 
-EXPOSE 8080
-ENV TUDOR_PORT=8080 \
-    TUDOR_HOST=0.0.0.0
+ARG VERSION=unknown
+ARG REVISION=unknown
 
 RUN echo "__version__ = '$VERSION'" > __version__.py
 ENV TUDOR_REVISION="$REVISION"
+
+LABEL \
+    Name="tudor" \
+    Version="$VERSION" \
+    Summary="A task manager app." \
+    Description="A task manager app." \
+    maintaner="izrik <izrik@izrik.com>"
 
 CMD ["/opt/tudor/start.sh"]


### PR DESCRIPTION
## Summary

- Upgrade gunicorn from 20.1.0 to 25.3.0 to fix `No module named pkg_resources` error on Python 3.12
- Re-arrange Dockerfile to improve build caching

## Test plan

- [ ] Build the Docker image and verify it starts without errors
- [ ] Verify gunicorn launches successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)