### PR TITLE
Extract markdown util and support newlines in table cells

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ COPY collections_util.py \
      gtudor.py \
      LICENSE \
      logging_util.py \
+     markdown_util.py \
      README.md \
      requirements.txt \
      tudor.py \

--- a/markdown_util.py
+++ b/markdown_util.py
@@ -1,0 +1,7 @@
+import pycmarkgfm
+
+
+def gfm_to_html(s):
+    output = pycmarkgfm.gfm_to_html(s)
+    output = output.replace('\\n', '<br/>')
+    return output

--- a/tests/test_markdown_util.py
+++ b/tests/test_markdown_util.py
@@ -1,0 +1,28 @@
+import unittest
+
+from markdown_util import gfm_to_html
+
+
+class GfmToHtmlTest(unittest.TestCase):
+    def test_renders_basic_markdown(self):
+        result = gfm_to_html('**bold**')
+        self.assertIn('<strong>bold</strong>', result)
+
+    def test_renders_table(self):
+        md = '| a | b |\n|---|---|\n| 1 | 2 |'
+        result = gfm_to_html(md)
+        self.assertIn('<table>', result)
+        self.assertIn('<td>1</td>', result)
+
+    def test_backslash_n_becomes_br_in_table_cell(self):
+        md = '| a | b |\n|---|---|\n| one\\ntwo | c |'
+        result = gfm_to_html(md)
+        self.assertIn('<td>one<br/>two</td>', result)
+
+    def test_backslash_n_becomes_br_outside_table(self):
+        result = gfm_to_html('foo\\nbar')
+        self.assertIn('foo<br/>bar', result)
+
+    def test_raw_html_still_sanitized(self):
+        result = gfm_to_html('<script>alert(1)</script>')
+        self.assertNotIn('<script>', result)

--- a/tudor.py
+++ b/tudor.py
@@ -14,7 +14,7 @@ from markupsafe import Markup
 from flask_bcrypt import Bcrypt
 from flask_login import LoginManager, login_required, current_user
 from flask_sqlalchemy import SQLAlchemy
-import pycmarkgfm
+from markdown_util import gfm_to_html
 
 from conversions import bool_from_str, int_from_str
 from logic.layer import LogicLayer
@@ -603,9 +603,7 @@ def generate_app(db_uri=None,
 
     @app.template_filter(name='gfm')
     def render_gfm(s):
-        output = pycmarkgfm.gfm_to_html(s)
-        moutput = Markup(output)
-        return moutput
+        return Markup(gfm_to_html(s))
 
     app.add_url_rule('/', None, index)
     app.add_url_rule('/hierarchy', None, hierarchy)


### PR DESCRIPTION
## Summary

- Extract GFM-to-HTML conversion to a standalone `markdown_util` module so it can be reused across projects
- Post-process rendered HTML to convert literal `\n` sequences into `<br/>` tags, allowing line breaks within table cells without enabling unsafe raw HTML
- Add tests for the new utility (basic markdown, tables, `\n` substitution, HTML sanitization)
- Add `markdown_util.py` to the Dockerfile COPY list

## Test plan

- [x] Run `pytest tests/test_markdown_util.py` and verify all tests pass
- [x] Run full test suite and verify no regressions
- [x] Manually verify that a task description with `\n` in a table cell renders with a line break

🤖 Generated with [Claude Code](https://claude.com/claude-code)